### PR TITLE
feat: 支持 Android Auto 显示与控制

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,29 @@
 
 ## 适用平台
 
-- Android（手机 / 平板 / Android TV）
+- Android（手机 / 平板 / Android TV / Android Auto 车机）
+
+## Android Auto 支持
+
+飞牛音乐通过 `audio_service` 注册系统 MediaSession / MediaBrowserService，
+支持在 Android Auto（手机投屏）与 Android Automotive OS（车机版）上显示和控制播放：
+
+- **启动器可见**：应用启动即注册媒体会话，Android Auto 启动器可直接发现本应用
+- **正在播放卡片**：显示封面、歌名、歌手、专辑与进度，支持上一首 / 播放暂停 / 下一首 / 拖动进度
+- **队列列表**：点按队列中的曲目可直接切歌
+- **通知联动**：通知栏与车机共用同一媒体会话，自定义按键（收藏 / 关闭）同步生效
+
+### 测试方式
+
+1. 手机安装本应用，并安装 Android Auto 应用
+2. 通过数据线连接支持 Android Auto 的车机（或使用 Android Auto 模拟器）
+3. 在车机启动器中选择「飞牛音乐」
+
+### 上架说明
+
+要在 Google Play 上架并支持 Android Auto，需要在 Play Console 中将应用
+**声明为媒体应用**并提交 Android Auto 审核，详见
+[Android Auto 媒体应用质量要求](https://developer.android.com/training/cars/media)。
 
 ## 界面预览
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -15,6 +15,11 @@
         <meta-data android:name="lyricon_module" android:value="true" />
         <meta-data android:name="lyricon_module_author" android:value="FeiNiuMusic" />
         <meta-data android:name="lyricon_module_description" android:value="FeiNiuMusic Lyricon Provider" />
+        <!-- Android Automotive OS（车机版）媒体应用身份：让车机 App 库
+             识别本应用为媒体应用。手机投屏 Android Auto 不需要此项。 -->
+        <meta-data
+            android:name="com.google.android.gms.car.application"
+            android:resource="@xml/automotive_app_desc" />
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/res/xml/automotive_app_desc.xml
+++ b/android/app/src/main/res/xml/automotive_app_desc.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Android Automotive OS（车机版）媒体应用声明：
+     Google 通过该文件把应用识别为媒体应用，纳入车机 App 库。
+     仅用于内置 Android 的车机（AAOS）；手机投屏 Android Auto 不需要
+     它，走的是 MediaBrowserService。 -->
+<automotiveApp>
+    <uses name="media" />
+</automotiveApp>

--- a/lib/app/services/media_notification_service.dart
+++ b/lib/app/services/media_notification_service.dart
@@ -27,6 +27,17 @@ class MediaNotificationService {
     final player = PlayerService.instance;
     final snap = player.snapshot.value;
     if (!force && snap.song == null && !snap.isPlaying) {
+      // Android Auto / 系统媒体中心通过 MediaBrowserService 发现应用：
+      // 即使当前没有播放内容也要注册 MediaSession，否则首次连接车机时
+      // 启动器里看不到本应用（要等用户手动播一首歌才会出现）。
+      // 其他平台保持原有延迟注册行为。
+      if (io.Platform.isAndroid) {
+        try {
+          await _initHandler();
+        } catch (e) {
+          _debugLog('eager init failed, will retry on first play: $e');
+        }
+      }
       if (_initListener == null) {
         _initListener = () {
           final current = player.snapshot.value;
@@ -41,27 +52,28 @@ class MediaNotificationService {
       }
       return;
     }
+    await _initHandler();
+  }
+
+  static Future<void> _initHandler() async {
+    if (_audioHandler != null || _initStarted) return;
     _initStarted = true;
-    _debugLog('init start force=$force');
-    if (io.Platform.isAndroid) {
-      final status = await Permission.notification.status;
-      if (!status.isGranted) {
-        _debugLog('requesting Android notification permission');
-        await Permission.notification.request();
-      }
+    _debugLog('init start');
+    try {
+      _audioHandler = await AudioService.init(
+        builder: () => _FeiNiuAudioHandler(PlayerService.instance),
+        config: const AudioServiceConfig(
+          androidNotificationChannelId: 'com.feiniu.music.playback',
+          androidNotificationChannelName: '音乐播放',
+          androidNotificationOngoing: true,
+          androidStopForegroundOnPause: true,
+          androidShowNotificationBadge: false,
+        ),
+      );
+      _debugLog('init completed');
+    } finally {
+      _initStarted = false;
     }
-    _audioHandler = await AudioService.init(
-      builder: () => _FeiNiuAudioHandler(PlayerService.instance),
-      config: const AudioServiceConfig(
-        androidNotificationChannelId: 'com.feiniu.music.playback',
-        androidNotificationChannelName: '音乐播放',
-        androidNotificationOngoing: true,
-        androidStopForegroundOnPause: true,
-        androidShowNotificationBadge: false,
-      ),
-    );
-    _debugLog('init completed');
-    _initStarted = false;
   }
 
   static void _debugLog(String message) {
@@ -81,6 +93,7 @@ class _FeiNiuAudioHandler extends BaseAudioHandler
   String? _lastMediaItemKey;
   String? _lastPlaybackStateKey;
   bool _supportsCustomActions = true;
+  bool _notificationPermissionRequested = false;
 
   // 封面本地缓存
   String? _coverDirPath;
@@ -347,7 +360,11 @@ class _FeiNiuAudioHandler extends BaseAudioHandler
         : AudioProcessingState.ready;
     return PlaybackState(
       controls: controls,
-      systemActions: const {MediaAction.seek},
+      systemActions: const {
+        MediaAction.seek,
+        MediaAction.skipToNext,
+        MediaAction.skipToPrevious,
+      },
       androidCompactActionIndices: const [0, 1, 2],
       processingState: processing,
       playing: playing,
@@ -360,8 +377,24 @@ class _FeiNiuAudioHandler extends BaseAudioHandler
 
   // ---- 同步方法 ----
 
+  // 通知权限在首次真正开始播放时才请求（保持原有交互），
+  // 避免应用启动时（仅注册 MediaSession 用于 Android Auto 发现）
+  // 就弹出系统权限对话框。
+  void _requestNotificationPermissionIfNeeded(PlaybackSnapshot snap) {
+    if (_notificationPermissionRequested || !snap.isPlaying) return;
+    _notificationPermissionRequested = true;
+    if (!io.Platform.isAndroid) return;
+    Permission.notification.status.then((status) {
+      if (!status.isGranted) {
+        _debugLog('requesting Android notification permission');
+        Permission.notification.request();
+      }
+    });
+  }
+
   void _syncFromPlayer() {
     final snap = player.snapshot.value;
+    _requestNotificationPermissionIfNeeded(snap);
     final songId = snap.song?.id;
     final songChanged = songId != _lastSongId;
     if (songId != _lastSongId) {
@@ -528,7 +561,9 @@ class _FeiNiuAudioHandler extends BaseAudioHandler
   @override
   Future<void> skipToQueueItem(int index) {
     _debugLog('skipToQueueItem action index=$index');
-    return player.next(); // 简化实现
+    // Android Auto / 系统媒体中心的队列列表点选曲目时调用，
+    // 必须真正跳到对应索引（原实现恒为 next()，点队列无效）。
+    return player.skipToIndex(index);
   }
 
   @override


### PR DESCRIPTION
## 新增功能

为应用添加 **Android Auto 支持**，让用户在车上通过 Android Auto 车机直接看到和控制播放：

- 播放开始前即可被 Android Auto 发现（Android 端启动即注册 MediaSession）
- 完善 MediaSession 系统动作：上一首 / 下一首 / 跳转到指定曲目
- 车机端显示封面、标题、歌手、播放进度，并支持播放/暂停/上一首/下一首/拖动进度
- 在 AndroidManifest 中声明 com.google.android.gms.car.application 车机元数据（automotive_app_desc.xml，<uses name="media"/>）

## 改动文件

- lib/app/services/media_notification_service.dart — MediaSession 注册时机与系统动作
- android/app/src/main/AndroidManifest.xml — 车机应用元数据
- android/app/src/main/res/xml/automotive_app_desc.xml — 新增，声明 media 用途
- README.md — 新增「Android Auto 支持」说明

## 验证

- flutter analyze：改动文件无告警
- flutter test：270/270 通过
- flutter build apk --release --split-per-abi 构建通过，APK 内已确认包含 MediaBrowserService 与车机元数据