### PR TITLE
feat(macOS): 菜单栏显示当前歌词

### DIFF
--- a/lib/app/services/macos_status_bar_service.dart
+++ b/lib/app/services/macos_status_bar_service.dart
@@ -5,6 +5,20 @@ import 'package:flutter/services.dart';
 
 import '../services/player_service.dart';
 import '../state/settings_state.dart';
+import 'lyrics/lyrics_service.dart';
+
+String resolveMacosStatusBarText({
+  required String songTitle,
+  required String? currentLyric,
+  required bool isPlaying,
+}) {
+  final normalizedTitle = songTitle.trim();
+  final normalizedLyric = currentLyric?.trim() ?? '';
+  if (isPlaying && normalizedLyric.isNotEmpty) {
+    return normalizedLyric;
+  }
+  return normalizedTitle;
+}
 
 /// macOS 菜单栏（状态栏）播放状态指示器。
 ///
@@ -33,6 +47,7 @@ class MacosStatusBarService {
     final state = AppPlayerState.instance;
     state.isPlaying.addListener(_pushState);
     state.currentSong.addListener(_pushState);
+    LyricsService.instance.currentLineText.addListener(_pushState);
 
     // Dart main() 与 AppDelegate 的 MethodChannel 注册没有固定先后顺序。
     // 主动握手并在失败后重试，避免首次 setState/hide 落在原生通道注册前，
@@ -84,9 +99,15 @@ class MacosStatusBarService {
     final state = AppPlayerState.instance;
     final song = state.currentSongSignal.value;
     final isPlaying = state.isPlayingSignal.value;
+    final currentLyric = LyricsService.instance.currentLineText.value;
     _send('setState', <String, Object?>{
       'title': song?.title ?? '',
       'artist': song?.artistDisplayName ?? '',
+      'displayText': resolveMacosStatusBarText(
+        songTitle: song?.title ?? '',
+        currentLyric: currentLyric,
+        isPlaying: isPlaying,
+      ),
       'isPlaying': isPlaying,
       'isIdle': song == null,
     });

--- a/lib/pages/settings/settings_page.dart
+++ b/lib/pages/settings/settings_page.dart
@@ -208,7 +208,7 @@ class _SettingsPageState extends State<SettingsPage> {
                       builder: (context, enabled, _) {
                         return AppSettingSwitchTile(
                           title: '状态栏播放状态',
-                          subtitle: '在 macOS 菜单栏显示当前歌曲与播放控制',
+                          subtitle: '播放时显示当前歌词，无歌词或暂停时显示歌曲名',
                           value: enabled,
                           onChanged: (value) {
                             StatusBarSettings.setEnabled(value);

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -66,6 +66,7 @@ private final class MacosStatusBarController: NSObject {
   private let methodChannel: FlutterMethodChannel
   private var lastTitle = "飞牛音乐"
   private var lastArtist = ""
+  private var displayText = "飞牛音乐"
   private var isPlaying = false
   private var isIdle = true
   private var isStatusItemVisible = true
@@ -151,6 +152,7 @@ private final class MacosStatusBarController: NSObject {
       if let args = call.arguments as? [String: Any] {
         lastTitle = (args["title"] as? String) ?? "飞牛音乐"
         lastArtist = (args["artist"] as? String) ?? ""
+        displayText = (args["displayText"] as? String) ?? lastTitle
         isPlaying = (args["isPlaying"] as? Bool) ?? false
         isIdle = (args["isIdle"] as? Bool) ?? false
         updateStatusItemTitle()
@@ -182,7 +184,7 @@ private final class MacosStatusBarController: NSObject {
   private func updateStatusItemTitle() {
     stopMarquee()
 
-    let title = isIdle || lastTitle.isEmpty ? "飞牛音乐" : lastTitle
+    let title = isIdle || displayText.isEmpty ? "飞牛音乐" : displayText
     guard let button = statusItem.button else { return }
     button.setAccessibilityLabel(title)
 

--- a/test/macos_status_bar_service_test.dart
+++ b/test/macos_status_bar_service_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:feiniu_music/app/services/macos_status_bar_service.dart';
+
+void main() {
+  group('resolveMacosStatusBarText', () {
+    test('shows the current lyric while playing', () {
+      expect(
+        resolveMacosStatusBarText(
+          songTitle: 'Song title',
+          currentLyric: '  Current lyric  ',
+          isPlaying: true,
+        ),
+        'Current lyric',
+      );
+    });
+
+    test('falls back to the song title when lyric is unavailable', () {
+      expect(
+        resolveMacosStatusBarText(
+          songTitle: ' Song title ',
+          currentLyric: '   ',
+          isPlaying: true,
+        ),
+        'Song title',
+      );
+    });
+
+    test('shows the song title while paused', () {
+      expect(
+        resolveMacosStatusBarText(
+          songTitle: 'Song title',
+          currentLyric: 'Current lyric',
+          isPlaying: false,
+        ),
+        'Song title',
+      );
+    });
+  });
+}


### PR DESCRIPTION
功能内容：播放时在 macOS 菜单栏显示当前歌词；无歌词或暂停时回退为歌曲名；下拉菜单和悬浮提示继续保留歌曲及歌手信息。\n\n验证：菜单栏文本选择逻辑单测 3 项通过；Flutter 静态分析通过；macOS Debug 构建成功。