### PR TITLE
fix(player): 修复桌面端迷你播放栏重影

### DIFF
--- a/lib/components/player/mini_player/mini_player_bar.dart
+++ b/lib/components/player/mini_player/mini_player_bar.dart
@@ -238,18 +238,21 @@ class MiniPlayerBar extends StatelessWidget {
                           // 之上。若把内容放进 BackdropFilter 内部，逐字歌词每帧
                           // 动画都会触发整页重新模糊，底栏就会卡顿；分层后动画
                           // 重绘只重绘内容层，不碰模糊层。
+                          //
+                          // BackdropFilter 不能放进 RepaintBoundary：它的结果依赖
+                          // 背后已经绘制的画面，桌面端窗口缩放/侧栏动画时若缓存
+                          // 该层，会复用旧位置的背景采样，形成整条播放栏重影。
                           Positioned.fill(
-                            child: RepaintBoundary(
-                              child: BackdropFilter(
-                                filter: ImageFilter.blur(
-                                  sigmaX: blurStrength,
-                                  sigmaY: blurStrength,
-                                ),
-                                child: const SizedBox.expand(),
+                            child: BackdropFilter(
+                              filter: ImageFilter.blur(
+                                sigmaX: blurStrength,
+                                sigmaY: blurStrength,
                               ),
+                              child: const SizedBox.expand(),
                             ),
                           ),
-                          content,
+                          // 缓存锐利的前景内容，而不是依赖背景采样的模糊层。
+                          RepaintBoundary(child: content),
                         ],
                       )
                     : content,

--- a/test/mini_player_swipe_test.dart
+++ b/test/mini_player_swipe_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:feiniu_music/app/services/player_service.dart';
+import 'package:feiniu_music/app/state/settings_state.dart';
 import 'package:feiniu_music/app/state/song_state.dart';
 import 'package:feiniu_music/components/player/mini_player/mini_player_bar.dart';
 
@@ -39,7 +40,6 @@ void main() {
 
     // 初始无提示（opacity 0）
     Opacity opacityOf(String text) {
-      final textWidget = tester.widget<Text>(find.text(text));
       final opacity = tester.widget<Opacity>(
         find.ancestor(of: find.text(text), matching: find.byType(Opacity)).first,
       );
@@ -78,5 +78,30 @@ void main() {
 
     await tester.pumpAndSettle();
     expect(opacityOf('下一曲').opacity, 0);
+  });
+
+  testWidgets('高斯模糊层不被缓存，避免桌面窗口变换时播放栏重影', (tester) async {
+    AppGlassSettings.liquidGlassEnabled.value = false;
+    AppBackgroundSettings.panelBlurEnabled.value = true;
+    AppBackgroundSettings.panelBlurStrength.value = 20;
+
+    await tester.pumpWidget(buildBar());
+    await tester.pump();
+
+    final backdrop = find.byType(BackdropFilter);
+    expect(backdrop, findsOneWidget);
+    var backdropCachedInsideBar = false;
+    tester.element(backdrop).visitAncestorElements((element) {
+      if (element.widget is MiniPlayerBar) return false;
+      if (element.widget is RepaintBoundary) backdropCachedInsideBar = true;
+      return true;
+    });
+    expect(backdropCachedInsideBar, isFalse);
+
+    final contentBoundary = find.descendant(
+      of: find.byType(MiniPlayerBar),
+      matching: find.byType(RepaintBoundary),
+    );
+    expect(contentBoundary, findsWidgets);
   });
 }


### PR DESCRIPTION
## 问题
1.6.1 在桌面端默认进入高斯模糊分支后，迷你播放栏在窗口缩放或侧栏过渡时会出现整栏重影。
## 原因
BackdropFilter 的输出依赖背后已经绘制的画面，但模糊层被放入 RepaintBoundary 缓存，桌面端合成变换时可能复用旧位置的背景采样。
## 修改
- 不再缓存 BackdropFilter 模糊层，保持背景实时采样
- 将 RepaintBoundary 移到锐利的前景内容层，继续隔离歌词动画重绘
- 增加回归测试，确保模糊层不位于播放栏内部的 RepaintBoundary 中
## 验证
- 相关 Flutter 测试：14/14 通过
- flutter analyze：无问题
- macOS Debug 构建成功