### PR TITLE
feat: Wi-Fi 下支持直连播放

### DIFF
--- a/lib/app/services/cast/dlna_cast_service.dart
+++ b/lib/app/services/cast/dlna_cast_service.dart
@@ -374,7 +374,10 @@ class DlnaCastService {
     //    （渲染器通用性最好）。失败则回退直连。
     final needsTranscode =
         FeiNiuTranscodeService.isMediaKitFormat(song.format ?? '') ||
-        await FeiNiuTranscodeService.instance.shouldTranscode(song);
+        await FeiNiuTranscodeService.instance.shouldTranscode(
+          song,
+          respectWifiPolicy: false,
+        );
     if (needsTranscode) {
       final hls = await FeiNiuTranscodeService.instance.transcodeMp3UrlFor(
         song,

--- a/lib/app/services/feiniu/transcode_service.dart
+++ b/lib/app/services/feiniu/transcode_service.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 
+import '../network_connection_service.dart';
 import '../../state/settings_transcode_state.dart';
 import '../../state/song_state.dart';
 import 'api_client.dart';
@@ -270,7 +271,10 @@ class FeiNiuTranscodeService {
   ///
   /// CUE 曲目也参与转码（服务器按 guid 返回**裁切好的单曲 HLS**，客户端无需
   /// 再裁剪）；CUE 整轨文件往往很大，转码后明显更小。
-  Future<bool> shouldTranscode(SongEntity song) async {
+  Future<bool> shouldTranscode(
+    SongEntity song, {
+    bool respectWifiPolicy = true,
+  }) async {
     // 桌面端（Windows/macOS/Linux）强制直连：转码产出 HLS（fMP4），
     // media_kit 的 mpv FFmpeg 音频库未编入 hls demuxer 播不了；
     // 全量走 media_kit 直连原始流即可。
@@ -285,6 +289,11 @@ class FeiNiuTranscodeService {
     // 直接请求该歌的转码地址播放。
     if (_forcedCodecs.containsKey(song.id)) return true;
     if (!AppTranscodeSettings.enabled.value) return false;
+    if (respectWifiPolicy &&
+        AppTranscodeSettings.directOnWifi.value &&
+        NetworkConnectionService.instance.isWifiConnected) {
+      return false;
+    }
     // 源格式与生效转码格式一致（flac→flac / mp3→mp3 / opus→opus）→ 无转码收益，
     // 直接直连播放。已降级到 mp3 的歌若源本就是 mp3 也跳过。
     final source = (song.format ?? '').trim().toLowerCase();
@@ -344,6 +353,10 @@ class FeiNiuTranscodeService {
     final forced = _forcedCodecs[song.id];
     if (forced != null) return forced.toUpperCase();
     if (!AppTranscodeSettings.enabled.value) return null;
+    if (AppTranscodeSettings.directOnWifi.value &&
+        NetworkConnectionService.instance.isWifiConnected) {
+      return null;
+    }
     final source = (song.format ?? '').trim().toLowerCase();
     if (source.isNotEmpty && source == effectiveCodecFor(song.id)) return null;
     // 不向上转码：输出质量层 ≥ 源质量层 → 直连（与 shouldTranscode 同源判定，

--- a/lib/app/services/network_connection_service.dart
+++ b/lib/app/services/network_connection_service.dart
@@ -1,0 +1,61 @@
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/foundation.dart';
+
+/// 维护当前设备的网络连接类型，供播放策略等需要同步读取网络类型的场景使用。
+///
+/// `connectivity_plus` 只表示可用的网络接口，不保证互联网实际可达；这里仅用它
+/// 区分 Wi-Fi 与蜂窝网络。只有明确包含 [ConnectivityResult.wifi] 才视为 Wi-Fi，
+/// VPN/未知网络按非 Wi-Fi 处理，避免误判后消耗蜂窝流量。
+class NetworkConnectionService {
+  NetworkConnectionService._();
+
+  static final NetworkConnectionService instance = NetworkConnectionService._();
+
+  final ValueNotifier<List<ConnectivityResult>> results =
+      ValueNotifier<List<ConnectivityResult>>(const []);
+  final ValueNotifier<bool> wifiConnected = ValueNotifier<bool>(false);
+
+  StreamSubscription<List<ConnectivityResult>>? _subscription;
+  Future<void>? _initializing;
+
+  bool get isWifiConnected => wifiConnected.value;
+
+  Future<void> init() => _initializing ??= _doInit();
+
+  Future<void> _doInit() async {
+    try {
+      _update(await Connectivity().checkConnectivity());
+    } catch (e) {
+      if (kDebugMode) {
+        debugPrint('[NetworkConnection] Initial check failed: $e');
+      }
+    }
+    _subscription ??= Connectivity().onConnectivityChanged.listen(
+      _update,
+      onError: (Object error) {
+        if (kDebugMode) {
+          debugPrint('[NetworkConnection] Change stream failed: $error');
+        }
+      },
+    );
+  }
+
+  void _update(List<ConnectivityResult> value) {
+    results.value = List<ConnectivityResult>.unmodifiable(value);
+    wifiConnected.value = value.contains(ConnectivityResult.wifi);
+    if (kDebugMode) {
+      debugPrint('[NetworkConnection] changed: $value, wifi=$isWifiConnected');
+    }
+  }
+
+  @visibleForTesting
+  void setResultsForTest(List<ConnectivityResult> value) => _update(value);
+
+  @visibleForTesting
+  void resetForTest() {
+    results.value = const [];
+    wifiConnected.value = false;
+  }
+}

--- a/lib/app/services/player_service.dart
+++ b/lib/app/services/player_service.dart
@@ -21,6 +21,7 @@ import 'feiniu/auth_service.dart';
 import 'feiniu/cue_service.dart';
 import 'feiniu/track_service.dart';
 import 'feiniu/transcode_service.dart';
+import 'network_connection_service.dart';
 import 'player/just_audio_engine.dart';
 import 'player/media_kit_engine.dart';
 import 'player/playback_router.dart';
@@ -124,6 +125,11 @@ class PlayerService with WidgetsBindingObserver {
   /// 网络缓慢提示计时器：media_kit 播无损大文件缓冲超时时触发一次提示。
   Timer? _slowNetworkTimer;
   bool _slowNetworkNotified = false;
+
+  /// Wi-Fi/蜂窝切换会改变转码路由。短暂防抖后保留当前进度重载当前 run，
+  /// 避免 just_audio 已预载的后续歌曲继续沿用切换前的直连/转码策略。
+  Timer? _networkRouteRefreshTimer;
+  bool _wifiDirectPolicyActive = false;
 
   final SongDao _songDao = SongDao.instance;
   final StatsService _statsService = StatsService.instance;
@@ -260,7 +266,60 @@ class PlayerService with WidgetsBindingObserver {
 
   PlayerService._internal() {
     WidgetsBinding.instance.addObserver(this);
+    _wifiDirectPolicyActive = AppTranscodeSettings.directOnWifi.value &&
+        NetworkConnectionService.instance.isWifiConnected;
+    NetworkConnectionService.instance.wifiConnected.addListener(
+      _scheduleNetworkRouteRefresh,
+    );
+    AppTranscodeSettings.directOnWifi.addListener(
+      _scheduleNetworkRouteRefresh,
+    );
     _initFuture = _init();
+  }
+
+  void _scheduleNetworkRouteRefresh() {
+    final active = AppTranscodeSettings.directOnWifi.value &&
+        NetworkConnectionService.instance.isWifiConnected;
+    if (active == _wifiDirectPolicyActive) return;
+    _wifiDirectPolicyActive = active;
+    if (queue.value.isEmpty || currentIndex.value < 0 || isCasting.value) return;
+    _networkRouteRefreshTimer?.cancel();
+    _networkRouteRefreshTimer = Timer(const Duration(milliseconds: 500), () {
+      unawaited(_refreshNetworkTranscodeRoute());
+    });
+  }
+
+  Future<void> _refreshNetworkTranscodeRoute() async {
+    try {
+      await _initFuture;
+      if (isCasting.value) return;
+      final list = queue.value;
+      final idx = currentIndex.value;
+      if (list.isEmpty || idx < 0 || idx >= list.length) return;
+
+      final seekPosition = position.value;
+      final wasPlaying = isPlaying.value;
+      final song = list[idx];
+      _debugLog(
+        'network route refresh wifi='
+        '${NetworkConnectionService.instance.isWifiConnected} song=${song.title}',
+      );
+
+      // 旧 HLS 不再代表当前网络策略，先清掉播放完成后的后台缓存标记并释放会话。
+      _activeTranscodeHlsUrl = null;
+      _activeTranscodeCodec = null;
+      await FeiNiuTranscodeService.instance.quitFor(song.id);
+
+      await _activateLogicalIndex(
+        idx,
+        initialPosition: seekPosition > Duration.zero ? seekPosition : null,
+      );
+      if (wasPlaying) await _startPlayback();
+    } catch (e) {
+      if (kDebugMode) {
+        debugPrint('[PlayerService] network route refresh failed: $e');
+      }
+    }
   }
 
   /// 初始化（含恢复旧播放会话）完成的 Future。所有播放操作先 await 它，
@@ -3906,6 +3965,14 @@ class PlayerService with WidgetsBindingObserver {
 
   Future<void> dispose() async {
     WidgetsBinding.instance.removeObserver(this);
+    NetworkConnectionService.instance.wifiConnected.removeListener(
+      _scheduleNetworkRouteRefresh,
+    );
+    AppTranscodeSettings.directOnWifi.removeListener(
+      _scheduleNetworkRouteRefresh,
+    );
+    _networkRouteRefreshTimer?.cancel();
+    _networkRouteRefreshTimer = null;
     // 释放全部服务器转码会话（fire-and-forget）。
     unawaited(FeiNiuTranscodeService.instance.quitAll());
     AppPlaybackVolumeSettings.volume.removeListener(_handleAppVolumeChanged);

--- a/lib/app/state/settings_transcode_state.dart
+++ b/lib/app/state/settings_transcode_state.dart
@@ -14,11 +14,14 @@ enum TranscodeFormat { flac, mp3, opus }
 ///   时生效；未识别大小的文件不转码。
 /// - [format]「转码格式」：flac 无损（带 bitrate:320）/ mp3 / opus（不带
 ///   bitrate——带 bitrate 会显著劣化音质）。
+/// - [directOnWifi]「Wi-Fi 下直连」：默认关闭；开启后仅自动转码在 Wi-Fi 下
+///   跳过，单曲手动指定转码格式仍然生效。
 class AppTranscodeSettings {
   static const String _prefsEnabled = 'transcode_enabled';
   static const String _prefsTranscodeAll = 'transcode_all';
   static const String _prefsThresholdMb = 'transcode_threshold_mb';
   static const String _prefsFormat = 'transcode_format';
+  static const String _prefsDirectOnWifi = 'transcode_direct_on_wifi';
 
   static const int defaultThresholdMb = 80;
   static const int minThresholdMb = 20;
@@ -29,6 +32,7 @@ class AppTranscodeSettings {
   static final ValueNotifier<int> thresholdMb = ValueNotifier(defaultThresholdMb);
   static final ValueNotifier<TranscodeFormat> format =
       ValueNotifier(TranscodeFormat.flac);
+  static final ValueNotifier<bool> directOnWifi = ValueNotifier(false);
 
   static Future<void>? _loading;
 
@@ -46,6 +50,7 @@ class AppTranscodeSettings {
       (f) => f.name == saved,
       orElse: () => TranscodeFormat.flac,
     );
+    directOnWifi.value = prefs.getBool(_prefsDirectOnWifi) ?? false;
   }
 
   static Future<void> setEnabled(bool value) async {
@@ -73,6 +78,12 @@ class AppTranscodeSettings {
     format.value = value;
   }
 
+  static Future<void> setDirectOnWifi(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_prefsDirectOnWifi, value);
+    directOnWifi.value = value;
+  }
+
   /// 测试专用：重置内存状态（清空懒加载缓存），供测试 setUp 复用。
   static void resetForTest() {
     _loading = null;
@@ -80,5 +91,6 @@ class AppTranscodeSettings {
     transcodeAll.value = true;
     thresholdMb.value = defaultThresholdMb;
     format.value = TranscodeFormat.flac;
+    directOnWifi.value = false;
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,6 +18,7 @@ import 'app/services/island_lyric_service.dart';
 import 'app/services/macos_status_bar_service.dart';
 import 'app/services/macos_window_background_service.dart';
 import 'app/services/media_notification_service.dart';
+import 'app/services/network_connection_service.dart';
 import 'app/services/portable_storage_service.dart';
 import 'app/services/tv_detection.dart';
 import 'app/services/track_change_overlay_service.dart';
@@ -89,6 +90,9 @@ Future<void> main() async {
   // 转码设置须在 PlayerService（MediaNotificationService.init）之前加载：
   // 启动恢复自动播放时 _sourceForSong 会同步读转码开关，未加载会读到默认关。
   await AppTranscodeSettings.ensureLoaded();
+  // 播放器构建队列前获取当前网络类型，使「Wi-Fi 下直连」首次播放即可生效；
+  // 后续网络切换由服务持续监听。
+  await NetworkConnectionService.instance.init();
   // 便携模式·换机检测：数据目录跟随 exe，若文件夹被拷到另一台电脑运行，
   // 自动清空本机 NAS 密码/token/安全码（保留服务器地址与用户名），
   // 避免把本机凭据带到别的机器。须在 AuthService.init（恢复会话）之前执行。

--- a/lib/pages/settings/transcode_settings_page.dart
+++ b/lib/pages/settings/transcode_settings_page.dart
@@ -57,6 +57,19 @@ class _TranscodeSettingsPageState extends State<TranscodeSettingsPage> {
                         valueListenable: AppTranscodeSettings.transcodeAll,
                         builder: (context, transcodeAll, _) {
                           final sub = <Widget>[
+                            ValueListenableBuilder<bool>(
+                              valueListenable:
+                                  AppTranscodeSettings.directOnWifi,
+                              builder: (context, directOnWifi, _) {
+                                return AppSettingSwitchTile(
+                                  title: 'Wi-Fi 下直连',
+                                  subtitle: '连接 Wi-Fi 时播放原始音频；蜂窝网络继续按转码设置播放',
+                                  value: directOnWifi,
+                                  onChanged:
+                                      AppTranscodeSettings.setDirectOnWifi,
+                                );
+                              },
+                            ),
                             AppSettingSwitchTile(
                               title: '全部转码',
                               subtitle: '开启 = 所有文件都转码（含无损，忽略大小阈值）；关闭 = 仅大文件转码',

--- a/test/settings_transcode_state_test.dart
+++ b/test/settings_transcode_state_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:feiniu_music/app/state/settings_transcode_state.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    AppTranscodeSettings.resetForTest();
+  });
+
+  test('Wi-Fi 下直连默认关闭，设置后持久化', () async {
+    await AppTranscodeSettings.ensureLoaded();
+    expect(AppTranscodeSettings.directOnWifi.value, isFalse);
+
+    await AppTranscodeSettings.setDirectOnWifi(true);
+    expect(AppTranscodeSettings.directOnWifi.value, isTrue);
+
+    AppTranscodeSettings.resetForTest();
+    await AppTranscodeSettings.ensureLoaded();
+    expect(AppTranscodeSettings.directOnWifi.value, isTrue);
+  });
+}

--- a/test/transcode_service_test.dart
+++ b/test/transcode_service_test.dart
@@ -1,9 +1,11 @@
 import 'package:dio/dio.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:feiniu_music/app/services/feiniu/api_client.dart';
 import 'package:feiniu_music/app/services/feiniu/transcode_service.dart';
+import 'package:feiniu_music/app/services/network_connection_service.dart';
 import 'package:feiniu_music/app/state/settings_transcode_state.dart';
 import 'package:feiniu_music/app/state/song_state.dart';
 
@@ -45,6 +47,7 @@ void main() {
 
   setUp(() {
     FeiNiuTranscodeService.instance.resetForTest();
+    NetworkConnectionService.instance.resetForTest();
     FeiNiuApiClient.instance.setDioForTest(
       _mockDio((o) => {
         'code': 0,
@@ -511,6 +514,66 @@ void main() {
       // 无损源 flac + 有损目标 mp3（真降级）→ 转码
       final song = _song('id-t1', format: 'flac');
       expect(await FeiNiuTranscodeService.instance.shouldTranscode(song), isTrue);
+    });
+
+    test('Wi-Fi 下直连开启 → 自动转码跳过，蜂窝网络仍转码', () async {
+      await AppTranscodeSettings.setEnabled(true);
+      await AppTranscodeSettings.setTranscodeAll(true);
+      await AppTranscodeSettings.setFormat(TranscodeFormat.mp3);
+      await AppTranscodeSettings.setDirectOnWifi(true);
+      final svc = FeiNiuTranscodeService.instance;
+      final song = _song('id-wifi', format: 'flac');
+
+      NetworkConnectionService.instance.setResultsForTest([
+        ConnectivityResult.wifi,
+      ]);
+      expect(await svc.shouldTranscode(song), isFalse);
+      expect(svc.configuredTranscodeLabel(song), isNull);
+
+      NetworkConnectionService.instance.setResultsForTest([
+        ConnectivityResult.mobile,
+      ]);
+      expect(await svc.shouldTranscode(song), isTrue);
+      expect(svc.configuredTranscodeLabel(song), 'MP3');
+    });
+
+    test('Wi-Fi 下手动指定格式仍转码，DLNA 可忽略 Wi-Fi 直连策略', () async {
+      await AppTranscodeSettings.setEnabled(true);
+      await AppTranscodeSettings.setTranscodeAll(true);
+      await AppTranscodeSettings.setFormat(TranscodeFormat.mp3);
+      await AppTranscodeSettings.setDirectOnWifi(true);
+      NetworkConnectionService.instance.setResultsForTest([
+        ConnectivityResult.wifi,
+      ]);
+      final svc = FeiNiuTranscodeService.instance;
+      final automatic = _song('id-wifi-auto', format: 'flac');
+
+      expect(
+        await svc.shouldTranscode(automatic, respectWifiPolicy: false),
+        isTrue,
+      );
+
+      final manual = _song('id-wifi-manual', format: 'flac');
+      svc.setForcedTranscodeCodec(manual.id, 'opus');
+      expect(await svc.shouldTranscode(manual), isTrue);
+      expect(svc.configuredTranscodeLabel(manual), 'OPUS');
+    });
+
+    test('VPN/未知网络不判作 Wi-Fi，保守地继续转码', () async {
+      await AppTranscodeSettings.setEnabled(true);
+      await AppTranscodeSettings.setTranscodeAll(true);
+      await AppTranscodeSettings.setFormat(TranscodeFormat.mp3);
+      await AppTranscodeSettings.setDirectOnWifi(true);
+      final svc = FeiNiuTranscodeService.instance;
+      final song = _song('id-vpn', format: 'flac');
+
+      NetworkConnectionService.instance.setResultsForTest([
+        ConnectivityResult.vpn,
+      ]);
+      expect(await svc.shouldTranscode(song), isTrue);
+
+      NetworkConnectionService.instance.setResultsForTest(const []);
+      expect(await svc.shouldTranscode(song), isTrue);
     });
 
     test('不向上转码：有损源 + flac 目标 → 直连（mp3→flac 纯浪费）', () async {


### PR DESCRIPTION
## 变更内容

- 在转码设置中新增“Wi-Fi 下直连”开关，仅在开启转码后显示
- Wi-Fi 环境下跳过自动转码，移动网络下继续遵循现有转码策略
- 保留单曲手动转码选择的优先级
- 网络状态变化时重新选择播放地址并保持播放进度
- DLNA 投屏不应用该 Wi-Fi 直连策略
- 补充转码策略和设置持久化测试

## 验证

- 相关转码、设置及 DLNA 测试通过（53 项）
- Android arm64-v8a 安装包真机验证设置项可见
- Android GitHub Actions 构建通过

Closes #63