### PR TITLE
修复一加13/Android15 播放闪退（Impeller SIGSEGV）

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -19,13 +19,20 @@
     <uses-permission android:name="android.permission.POST_PROMOTED_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <application
-        android:label="${appLabel}"
-        android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher"
-        android:banner="@mipmap/ic_launcher"
-        android:usesCleartextTraffic="true"
-        android:enableOnBackInvokedCallback="true">
-        <meta-data android:name="lyricon_module" android:value="true" />
+       android:label="${appLabel}"
+       android:name="${applicationName}"
+       android:icon="@mipmap/ic_launcher"
+       android:banner="@mipmap/ic_launcher"
+       android:usesCleartextTraffic="true"
+       android:enableOnBackInvokedCallback="true">
+       <!-- 禁用 Impeller 渲染器（回退 Skia）：
+            一加13（骁龙8Elite/Adreno830）+ Android15 上 Impeller 光栅线程
+            纹理初始化空指针崩溃（SIGSEGV, tid 1.raster, 切歌后~6s 触发）。
+            回退 Skia 可绕过该引擎级 bug。 -->
+       <meta-data
+           android:name="io.flutter.embedding.android.EnableImpeller"
+           android:value="false" />
+       <meta-data android:name="lyricon_module" android:value="true" />
         <meta-data android:name="lyricon_module_author" android:value="FeiNiuMusic" />
         <meta-data android:name="lyricon_module_description" android:value="FeiNiuMusic Lyricon Provider" />
         <!-- Android Automotive OS（车机版）媒体应用身份：让车机 App 库

--- a/lib/components/player/karaoke_lyric_text.dart
+++ b/lib/components/player/karaoke_lyric_text.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter_lyric/core/lyric_model.dart';
 
 import '../../app/services/lyrics/lyrics_service.dart';
@@ -116,6 +117,32 @@ class _KaraokeLyricTextState extends State<KaraokeLyricText>
   }
 
   void _updateTarget() {
+    if (!mounted) return;
+    // 若 position 通知恰好落在 build/layout 帧内（播放中逐帧驱动时可能发生），
+    // 同步改 _controller 会触发监听它的 ValueListenableBuilder 同步
+    // markNeedsBuild → “setState called during build” 级联崩溃。
+    // 非安全期先登记，帧后统一执行。
+    if (SchedulerBinding.instance.schedulerPhase !=
+        SchedulerPhase.idle) {
+      _scheduleTargetUpdate();
+      return;
+    }
+    _applyTargetUpdate();
+  }
+
+  bool _targetUpdateScheduled = false;
+
+  void _scheduleTargetUpdate() {
+    if (_targetUpdateScheduled) return;
+    _targetUpdateScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _targetUpdateScheduled = false;
+      if (!mounted) return;
+      _applyTargetUpdate();
+    });
+  }
+
+  void _applyTargetUpdate() {
     if (!mounted) return;
     final line = widget.line;
     final text = line.text;
@@ -284,6 +311,9 @@ class _KaraokeLyricTextState extends State<KaraokeLyricText>
     if (explicitBase != null && explicitHighlight != null) {
       return _buildContent(context, explicitBase, explicitHighlight);
     }
+    // 颜色变化只触发重建，不在 build 期同步读 notifier（避免信号同步镜像
+    // 触发循环 markNeedsBuild → “setState called during build” 级联崩溃）。
+    // builder 里延迟到帧后回调再读颜色，首帧用兜底值，帧后立即校正。
     return ListenableBuilder(
       listenable: Listenable.merge([
         lyrics.viewInactiveColor,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:ui' show PlatformDispatcher;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -52,6 +53,23 @@ Future<void> main() async {
     debugPrint('MediaKit.ensureInitialized failed: $e');
   }
   await DebugLogService.instance.ensureLoaded();
+  // 全局异常捕获：release 下 Flutter 默认只输出无信息的
+  // “Another exception was thrown: Instance of 'DiagnosticsProperty<void>'”
+  // 级联产物，真异常（含堆栈）被吞，无法定位闪退根因。这里把首条异常
+  // + 堆栈写入调试日志（设置→版本信息→导出日志可见），同时转发给原 handler。
+  final originalFlutterError = FlutterError.onError;
+  FlutterError.onError = (FlutterErrorDetails details) {
+    DebugLogService.instance
+        .add('[FlutterError] ${details.exceptionAsString()}\n'
+            '${details.stack ?? ''}');
+    originalFlutterError?.call(details);
+  };
+  PlatformDispatcher.instance.onError = (error, stack) {
+    DebugLogService.instance
+        .add('[PlatformDispatcher] $error\n$stack');
+    // 返回 false：仅记录，不拦截默认崩溃处理（避免掩盖真正的进程级错误）
+    return false;
+  };
   // TV 检测必须在 runApp 前完成，避免首帧后再切换布局造成闪变。
   // TV 面板固定 60Hz，强制高刷无意义甚至闪烁，因此高刷调用跳过 TV。
   await TvDetection.ensureLoaded();


### PR DESCRIPTION
一加13（Android 15）上播放会闪退，基本每次切歌后几秒就崩，挺稳定的复现。

抓了下 tombstone，是 libflutter.so 里光栅线程（1.raster）空指针 SIGSEGV，符号定位到 InternalFlutterGpu_Texture_InitializeFromImage 附近——Impeller 做纹理上传初始化的时候崩的。看起来是 Impeller 在骁龙 8 Elite（Adreno 830）上的引擎级问题，不是 app 代码的事，栈里全是引擎帧。

试了下在 AndroidManifest 里把 Impeller 关掉（EnableImpeller=false，回退 Skia），手机实测连续切歌不再闪退，目前用下来没问题。另外逐字歌词那个组件有个 build 期改动画控制器的隐患顺手也修了（防止偶发 setState during build 的级联报错），还在 main 里加了全局异常捕获，以后真有异常会带堆栈写进调试日志，导出就能看。

改动就三个文件：
- AndroidManifest.xml：禁 Impeller
- karaoke_lyric_text.dart：动画更新加 build 期守卫
- main.dart：全局异常捕获

本地 flutter analyze 通过，修复版 APK 在实机验证过了。长期建议还是升级 Flutter 引擎，Impeller 在 Adreno 830 上的这个问题新版引擎大概率已经修了。
