### PR TITLE
fix(library): preserve paged scroll position after detail return

### DIFF
--- a/lib/pages/library/albums_page.dart
+++ b/lib/pages/library/albums_page.dart
@@ -17,6 +17,7 @@ import '../../app/utils/deferred_page_init_mixin.dart';
 import '../../components/index.dart';
 import '../../pages/search/search_page.dart';
 import 'library_detail_pages.dart';
+import 'library_metadata.dart';
 
 class AlbumsPage extends StatefulWidget {
   const AlbumsPage({super.key});
@@ -179,6 +180,27 @@ class _AlbumsPageState extends State<AlbumsPage>
     } finally {
       if (mounted) _loadingMore.value = false;
     }
+  }
+
+  void _applyMetadataUpdate(String guid, LibraryEntityMetadata metadata) {
+    if (!_groups.value.any((group) => group.album.guid == guid)) return;
+    final albums = replaceAlbumMetadata(
+      _groups.value.map((group) => group.album).toList(),
+      guid,
+      metadata,
+    );
+    final groups = albums.map(AlbumGroup.fromFeiNiuAlbum).toList();
+    _groups.value = groups;
+
+    unawaited(
+      ApiCacheManager.instance.set(
+        scope: 'album_list',
+        key: 'page=1&size=$_pageSize',
+        jsonData: jsonEncode(
+          groups.take(_pageSize).map((group) => group.toJson()).toList(),
+        ),
+      ),
+    );
   }
 
   Future<void> _init() async {
@@ -509,18 +531,19 @@ class _AlbumsPageState extends State<AlbumsPage>
                   final g = _groups.value[index];
                   return InkWell(
                     borderRadius: BorderRadius.circular(16),
-                    onTap: () async {
-                      await Navigator.of(context).push(
+                    onTap: () {
+                      Navigator.of(context).push(
                         buildAppPageRoute(
                           (_) => AlbumDetailPage(
                             albumName: g.name,
                             albumGuid: g.album.guid,
+                            onMetadataChanged: (metadata) {
+                              if (!mounted) return;
+                              _applyMetadataUpdate(g.album.guid, metadata);
+                            },
                           ),
                         ),
                       );
-                      // 返回后强制刷新（编辑可能改了名称/封面，重写 ApiCacheManager 缓存）
-                      if (!mounted) return;
-                      _load(forceRefresh: true);
                     },
                     onLongPress: () {},
                     child: Padding(

--- a/lib/pages/library/artists_page.dart
+++ b/lib/pages/library/artists_page.dart
@@ -16,6 +16,7 @@ import '../../app/utils/deferred_page_init_mixin.dart';
 import '../../components/index.dart';
 import '../../pages/search/search_page.dart';
 import 'library_detail_pages.dart';
+import 'library_metadata.dart';
 
 class ArtistsPage extends StatefulWidget {
   const ArtistsPage({super.key});
@@ -126,6 +127,27 @@ class _ArtistsPageState extends State<ArtistsPage>
     } finally {
       if (mounted) _loadingMore.value = false;
     }
+  }
+
+  void _applyMetadataUpdate(String guid, LibraryEntityMetadata metadata) {
+    if (!_groups.value.any((group) => group.artist.guid == guid)) return;
+    final artists = replaceArtistMetadata(
+      _groups.value.map((group) => group.artist).toList(),
+      guid,
+      metadata,
+    );
+    final groups = artists.map(ArtistGroup.fromFeiNiuArtist).toList();
+    _groups.value = groups;
+
+    unawaited(
+      ApiCacheManager.instance.set(
+        scope: 'artist_list',
+        key: 'page=1&size=$_pageSize',
+        jsonData: jsonEncode(
+          groups.take(_pageSize).map((group) => group.toJson()).toList(),
+        ),
+      ),
+    );
   }
 
   Future<void> _init() async {
@@ -389,15 +411,19 @@ class _ArtistsPageState extends State<ArtistsPage>
             selected: false,
             multiSelect: false,
             isHighlighted: false,
-            onTap: () async {
-              await Navigator.of(context).push(
+            onTap: () {
+              Navigator.of(context).push(
                 buildAppPageRoute(
-                  (_) => ArtistDetailPage(artistName: g.name, artistGuid: g.artist.guid),
+                  (_) => ArtistDetailPage(
+                    artistName: g.name,
+                    artistGuid: g.artist.guid,
+                    onMetadataChanged: (metadata) {
+                      if (!mounted) return;
+                      _applyMetadataUpdate(g.artist.guid, metadata);
+                    },
+                  ),
                 ),
               );
-              // 返回后强制刷新（编辑可能改了名称/封面，重写 ApiCacheManager 缓存）
-              if (!mounted) return;
-              _load(forceRefresh: true);
             },
             onLongPress: () {},
           );

--- a/lib/pages/library/library_detail_pages.dart
+++ b/lib/pages/library/library_detail_pages.dart
@@ -18,6 +18,7 @@ import '../../app/state/song_state.dart';
 import '../../components/index.dart';
 import '../songs/song_detail_sheet.dart';
 import 'artist_album_edit_page.dart';
+import 'library_metadata.dart';
 
 List<String> splitArtists(String raw) {
   final text = raw.trim();
@@ -107,11 +108,13 @@ List<SongEntity> sortAlbumDetailSongs(
 class ArtistDetailPage extends StatefulWidget {
   final String artistName;
   final String? artistGuid;
+  final ValueChanged<LibraryEntityMetadata>? onMetadataChanged;
 
   const ArtistDetailPage({
     super.key,
     required this.artistName,
     this.artistGuid,
+    this.onMetadataChanged,
   });
 
   @override
@@ -188,6 +191,7 @@ class _ArtistDetailPageState extends State<ArtistDetailPage>
   Future<void> _openEdit() async {
     final guid = widget.artistGuid;
     if (guid == null) return;
+    final previousCoverId = _artistCoverIdFor(_songs.value, guid);
     final result = await Navigator.of(context).push<String>(
       buildAppPageRoute(
         (_) => ArtistAlbumEditPage(
@@ -200,7 +204,14 @@ class _ArtistDetailPageState extends State<ArtistDetailPage>
     );
     if (!mounted || result == null) return;
     setState(() => _artistName = result);
-    _load();
+    await _load();
+    if (!mounted) return;
+    widget.onMetadataChanged?.call(
+      LibraryEntityMetadata(
+        name: _artistName,
+        coverId: _artistCoverIdFor(_songs.value, guid) ?? previousCoverId,
+      ),
+    );
   }
 
   Future<void> _load() async {
@@ -611,11 +622,13 @@ class _ArtistDetailPageState extends State<ArtistDetailPage>
 class AlbumDetailPage extends StatefulWidget {
   final String albumName;
   final String? albumGuid;
+  final ValueChanged<LibraryEntityMetadata>? onMetadataChanged;
 
   const AlbumDetailPage({
     super.key,
     required this.albumName,
     this.albumGuid,
+    this.onMetadataChanged,
   });
 
   @override
@@ -678,6 +691,7 @@ class _AlbumDetailPageState extends State<AlbumDetailPage>
   Future<void> _openEdit() async {
     final guid = widget.albumGuid;
     if (guid == null) return;
+    final previousCoverId = _songs.value.firstOrNull?.albumCoverId;
     final result = await Navigator.of(context).push<String>(
       buildAppPageRoute(
         (_) => ArtistAlbumEditPage(
@@ -690,7 +704,14 @@ class _AlbumDetailPageState extends State<AlbumDetailPage>
     );
     if (!mounted || result == null) return;
     setState(() => _albumName = result);
-    _load();
+    await _load();
+    if (!mounted) return;
+    widget.onMetadataChanged?.call(
+      LibraryEntityMetadata(
+        name: _albumName,
+        coverId: _songs.value.firstOrNull?.albumCoverId ?? previousCoverId,
+      ),
+    );
   }
 
   Future<void> _load() async {

--- a/lib/pages/library/library_metadata.dart
+++ b/lib/pages/library/library_metadata.dart
@@ -1,0 +1,43 @@
+import '../../app/services/feiniu/api_models.dart';
+
+class LibraryEntityMetadata {
+  final String name;
+  final String? coverId;
+
+  const LibraryEntityMetadata({required this.name, this.coverId});
+}
+
+List<FeiNiuAlbum> replaceAlbumMetadata(
+  List<FeiNiuAlbum> source,
+  String guid,
+  LibraryEntityMetadata metadata,
+) {
+  return source.map((album) {
+    if (album.guid != guid) return album;
+    return FeiNiuAlbum(
+      guid: album.guid,
+      name: metadata.name,
+      coverId: metadata.coverId ?? album.coverId,
+      releaseDate: album.releaseDate,
+      trackCount: album.trackCount,
+      createdAt: album.createdAt,
+    );
+  }).toList();
+}
+
+List<FeiNiuArtist> replaceArtistMetadata(
+  List<FeiNiuArtist> source,
+  String guid,
+  LibraryEntityMetadata metadata,
+) {
+  return source.map((artist) {
+    if (artist.guid != guid) return artist;
+    return FeiNiuArtist(
+      guid: artist.guid,
+      name: metadata.name,
+      coverId: metadata.coverId ?? artist.coverId,
+      trackCount: artist.trackCount,
+      albumCount: artist.albumCount,
+    );
+  }).toList();
+}

--- a/test/library_metadata_update_test.dart
+++ b/test/library_metadata_update_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:feiniu_music/app/services/feiniu/api_models.dart';
+import 'package:feiniu_music/pages/library/library_metadata.dart';
+
+void main() {
+  test('album metadata replacement preserves loaded pages and item order', () {
+    final source = List.generate(
+      205,
+      (index) => FeiNiuAlbum(
+        guid: 'album-$index',
+        name: 'Album $index',
+        coverId: 'cover-$index',
+        trackCount: index,
+      ),
+    );
+
+    final updated = replaceAlbumMetadata(
+      source,
+      'album-150',
+      const LibraryEntityMetadata(name: 'Renamed album', coverId: 'new-cover'),
+    );
+
+    expect(updated, hasLength(205));
+    expect(
+      updated.map((album) => album.guid),
+      source.map((album) => album.guid),
+    );
+    expect(updated[150].name, 'Renamed album');
+    expect(updated[150].coverId, 'new-cover');
+    expect(updated[150].trackCount, 150);
+    expect(source[150].name, 'Album 150');
+  });
+
+  test('artist metadata replacement preserves loaded pages and item order', () {
+    final source = List.generate(
+      205,
+      (index) => FeiNiuArtist(
+        guid: 'artist-$index',
+        name: 'Artist $index',
+        coverId: 'cover-$index',
+        trackCount: index,
+        albumCount: index ~/ 2,
+      ),
+    );
+
+    final updated = replaceArtistMetadata(
+      source,
+      'artist-150',
+      const LibraryEntityMetadata(name: 'Renamed artist', coverId: 'new-cover'),
+    );
+
+    expect(updated, hasLength(205));
+    expect(
+      updated.map((artist) => artist.guid),
+      source.map((artist) => artist.guid),
+    );
+    expect(updated[150].name, 'Renamed artist');
+    expect(updated[150].coverId, 'new-cover');
+    expect(updated[150].trackCount, 150);
+    expect(updated[150].albumCount, 75);
+    expect(source[150].name, 'Artist 150');
+  });
+}


### PR DESCRIPTION
## Summary

- preserve paginated album and artist list state when returning from detail pages
- update edited name and cover metadata in place without resetting loaded pages or scroll position
- add regression tests covering metadata updates beyond the first page

## Verification

- flutter test test/library_metadata_update_test.dart
- targeted flutter analyze for changed files
- Android Debug APK build: https://github.com/qbmzc/FeiNiuMusic/actions/runs/33289307958

Closes #68