### PR TITLE
fix(player): bound desktop playback memory usage

### DIFF
--- a/lib/app/services/player/media_kit_engine.dart
+++ b/lib/app/services/player/media_kit_engine.dart
@@ -5,6 +5,30 @@ import 'package:media_kit/media_kit.dart' as mk;
 
 import 'player_engine.dart';
 
+const _desktopAudioOnlyProperties = <String, String>{
+  'cache-on-disk': 'no',
+  'audio-display': 'no',
+  'vid': 'no',
+};
+
+/// Apply the libmpv properties required by the desktop audio-only player.
+///
+/// Each property is isolated so an unsupported option in one libmpv build does
+/// not prevent the remaining memory-safety options from being applied.
+@visibleForTesting
+Future<void> configureMediaKitDesktopAudioOnly({
+  required Future<void> Function(String property, String value) setProperty,
+  void Function(String property, Object error)? onError,
+}) async {
+  for (final entry in _desktopAudioOnlyProperties.entries) {
+    try {
+      await setProperty(entry.key, entry.value);
+    } catch (error) {
+      onError?.call(entry.key, error);
+    }
+  }
+}
+
 /// media_kit 会在播放列表中的**每一首**结束时短暂上报 completed=true，
 /// 随后自行推进到下一项；业务层只应在物理播放列表最后一项结束时处理完成，
 /// 否则会与 media_kit 的自动推进叠加，造成一次跳过两首。
@@ -111,19 +135,25 @@ class MediaKitEngine implements PlayerEngine {
       ),
     );
     _player = player;
-    // media_kit 默认启用 mpv cache-on-disk。macOS 沙盒与部分 Windows 环境
-    // （无法访问 mpv 默认缓存目录）下 mpv 创建其文件缓存失败，日志为
-    // "Failed to create file cache"，随后 FLAC 流可能在曲末报 invalid frame
-    // header。关闭磁盘层，仅保留既有 32MB 内存 demux 缓存；应用自己的
-    // StreamCacheService 仍负责完整歌曲落盘。
+    // 桌面端这个 libmpv 实例只用于音频：
+    // - 关闭 cache-on-disk，避免沙盒内创建 mpv 默认文件缓存失败；
+    // - 关闭 audio-display/vid，避免 mpv 把 DSD/FLAC 的高分辨率内嵌封面
+    //   当作视频轨解码，切歌后继续占用 VideoToolbox/GPU 图形内存。
+    // 应用自己的 StreamCacheService 仍负责完整歌曲落盘，Flutter UI
+    // 使用服务器封面，因此禁用 mpv 封面显示不会影响播放页。
     if (defaultTargetPlatform == TargetPlatform.macOS ||
         defaultTargetPlatform == TargetPlatform.windows) {
-      try {
-        final dynamic nativePlayer = player.platform;
-        await nativePlayer.setProperty('cache-on-disk', 'no');
-      } catch (e) {
-        debugPrint('[MediaKitEngine] disable disk cache failed: $e');
-      }
+      final dynamic nativePlayer = player.platform;
+      await configureMediaKitDesktopAudioOnly(
+        setProperty: (property, value) async {
+          await nativePlayer.setProperty(property, value);
+        },
+        onError: (property, error) {
+          debugPrint(
+            '[MediaKitEngine] set desktop property $property failed: $error',
+          );
+        },
+      );
     }
     // 订阅 mpv 原生日志：仅保留错误级别（PlayerConfiguration.logLevel=error），
     // 诊断加载/解码失败的具体原因。不依赖 kDebugMode：release 版经 DebugLogService

--- a/lib/app/utils/route_visibility.dart
+++ b/lib/app/utils/route_visibility.dart
@@ -9,15 +9,17 @@ final RouteObserver<ModalRoute<void>> appRouteObserver =
 
 /// 让动画控制器在路由被覆盖时自动暂停、重新可见时恢复。
 ///
-/// 用法：让持有常驻动画的 State 同时 `with SingleTickerProviderStateMixin,
+/// 用法：让持有常驻动画的 State 同时 `with TickerProviderStateMixin,
 /// AppRouteVisibilityMixin`，并覆写 [resumeVisibilityAnimation] 定义恢复行为
 /// （默认 `controller.repeat()`）。当页面被 push 到其上（didPushNext）时暂停，
 /// 回到当前页（didPopNext）时恢复。页面本身可见时动画不受影响。
-mixin AppRouteVisibilityMixin<T extends StatefulWidget>
-    on State<T>, SingleTickerProviderStateMixin<T>
+mixin AppRouteVisibilityMixin<T extends StatefulWidget> on State<T>
     implements RouteAware {
   /// 需要随可见性暂停/恢复的动画控制器。
   AnimationController get visibilityController;
+
+  /// 需要一起暂停的额外控制器（例如背景换色过渡）。
+  Iterable<AnimationController> get additionalVisibilityControllers => const [];
 
   /// 页面重新成为当前路由时如何恢复动画。默认重新 repeat；
   /// 需要条件恢复（如仅播放中旋转封面）时覆写此方法。
@@ -35,6 +37,9 @@ mixin AppRouteVisibilityMixin<T extends StatefulWidget>
   void didPushNext() {
     // 被其它路由覆盖：暂停动画，停止消耗 GPU 帧预算。
     visibilityController.stop();
+    for (final controller in additionalVisibilityControllers) {
+      controller.stop();
+    }
   }
 
   @override

--- a/lib/components/common/artwork_widget.dart
+++ b/lib/components/common/artwork_widget.dart
@@ -4,6 +4,7 @@ import 'package:signals_flutter/signals_flutter.dart';
 
 import '../../app/services/feiniu/api_client.dart';
 import '../../app/state/song_state.dart';
+import 'cover_image_cache.dart';
 
 class ArtworkWidget extends StatefulWidget {
   final SongEntity song;
@@ -75,6 +76,7 @@ class _ArtworkWidgetState extends State<ArtworkWidget> with SignalsMixin {
     final coverId = widget.song.coverId;
     final size = widget.size;
     final borderRadius = widget.borderRadius;
+    final memoryCacheSize = coverMemoryCacheDimensionOf(context, size);
 
     final placeholder =
         widget.placeholder ??
@@ -93,12 +95,11 @@ class _ArtworkWidgetState extends State<ArtworkWidget> with SignalsMixin {
       // 构造同一个 URL → 共享同一份磁盘缓存与解码缓存。此前按显示尺寸×DPR
       // 动态请求（列表 120 起步、播放页 800），同一封面在不同页面产生多个
       // 不同 URL 的缓存，已显示过的地方命中缓存、另一处仍在转圈下载。
-      final coverUrl =
-          FeiNiuApiClient.instance.coverUrl(
-            coverId,
-            size: FeiNiuApiClient.coverRequestSize,
-            updatedAt: widget.song.updatedAt,
-          );
+      final coverUrl = FeiNiuApiClient.instance.coverUrl(
+        coverId,
+        size: FeiNiuApiClient.coverRequestSize,
+        updatedAt: widget.song.updatedAt,
+      );
       child = ClipRRect(
         borderRadius: BorderRadius.circular(borderRadius),
         child: CachedNetworkImage(
@@ -106,6 +107,8 @@ class _ArtworkWidgetState extends State<ArtworkWidget> with SignalsMixin {
           httpHeaders: _authHeaders(),
           width: size,
           height: size,
+          memCacheWidth: memoryCacheSize,
+          memCacheHeight: memoryCacheSize,
           fit: BoxFit.cover,
           // 真实封面解码成功 → 上报可用（供播放页判断是否旋转）
           imageBuilder: (context, imageProvider) {

--- a/lib/components/common/cover_image_cache.dart
+++ b/lib/components/common/cover_image_cache.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/widgets.dart';
+
+import '../../app/services/feiniu/api_client.dart';
+
+/// Returns the decoded square-cover dimension for a logical display size.
+///
+/// Cover URLs stay at the canonical 800px size so network and disk caches are
+/// shared. Only the in-memory decode is resized to the pixels the screen needs.
+int coverMemoryCacheDimension({
+  required double logicalSize,
+  required double devicePixelRatio,
+  int maxDimension = FeiNiuApiClient.coverRequestSize,
+}) {
+  if (!logicalSize.isFinite || logicalSize <= 0) return 1;
+  if (!devicePixelRatio.isFinite || devicePixelRatio <= 0) return 1;
+  return (logicalSize * devicePixelRatio).ceil().clamp(1, maxDimension).toInt();
+}
+
+int coverMemoryCacheDimensionOf(BuildContext context, double logicalSize) {
+  return coverMemoryCacheDimension(
+    logicalSize: logicalSize,
+    devicePixelRatio: MediaQuery.devicePixelRatioOf(context),
+  );
+}

--- a/lib/components/index.dart
+++ b/lib/components/index.dart
@@ -1,6 +1,7 @@
 export 'common/alphabet_indexer.dart';
 export 'common/app_list_tile.dart';
 export 'common/artwork_widget.dart';
+export 'common/cover_image_cache.dart';
 export 'common/glass_panel.dart';
 export 'common/labeled_slider.dart';
 export 'common/playing_bars.dart';

--- a/lib/pages/home/home_page.dart
+++ b/lib/pages/home/home_page.dart
@@ -223,6 +223,7 @@ class _HomePageState extends State<HomePage>
     if (!mounted) return;
     final api = FeiNiuApiClient.instance;
     final headers = FeiNiuApiClient.imageAuthHeaders();
+    final memoryCacheSize = coverMemoryCacheDimensionOf(context, 160);
     // 预加载首页所有可见封面（最多 40 张）
     final coverUrls = <String>[
       // Hero Banner 主视觉 — 大尺寸首帧
@@ -276,7 +277,11 @@ class _HomePageState extends State<HomePage>
       try {
         unawaited(
           precacheImage(
-            CachedNetworkImageProvider(url, headers: headers),
+            ResizeImage.resizeIfNeeded(
+              memoryCacheSize,
+              memoryCacheSize,
+              CachedNetworkImageProvider(url, headers: headers),
+            ),
             context,
           ),
         );

--- a/lib/pages/home/widgets/home_cover_carousel.dart
+++ b/lib/pages/home/widgets/home_cover_carousel.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 import '../../../app/services/feiniu/api_client.dart';
 import '../../../app/state/settings_layout_state.dart';
+import '../../../components/common/cover_image_cache.dart';
 import '../../../components/focus/tv_focusable.dart';
 
 /// 横向封面轮播单项数据
@@ -95,6 +96,7 @@ class _CarouselCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final coverId = item.coverId;
     final isTv = AppLayoutSettings.tvMode.value;
+    final memoryCacheSize = coverMemoryCacheDimensionOf(context, coverSize);
     final card = SizedBox(
       width: coverSize,
       child: GestureDetector(
@@ -123,6 +125,8 @@ class _CarouselCard extends StatelessWidget {
                         httpHeaders: authHeaders,
                         width: coverSize,
                         height: coverSize,
+                        memCacheWidth: memoryCacheSize,
+                        memCacheHeight: memoryCacheSize,
                         fit: BoxFit.cover,
                         placeholder: (_, _) => _coverPlaceholder(),
                         errorWidget: (_, _, _) => _coverPlaceholder(),

--- a/lib/pages/home/widgets/home_large_layout.dart
+++ b/lib/pages/home/widgets/home_large_layout.dart
@@ -7,6 +7,7 @@ import '../../../app/services/feiniu/api_models.dart';
 import '../../../app/state/settings_layout_state.dart';
 import '../../../app/state/song_state.dart';
 import '../../../components/common/artwork_widget.dart';
+import '../../../components/common/cover_image_cache.dart';
 import '../../../components/focus/tv_focusable.dart';
 import 'home_cover_carousel.dart';
 import 'home_hero_banner.dart';
@@ -431,6 +432,7 @@ class _PlaylistCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final coverId = playlist.coverId;
+    final memoryCacheSize = coverMemoryCacheDimensionOf(context, 150);
     final card = SizedBox(
       width: 150,
       child: Column(
@@ -454,6 +456,8 @@ class _PlaylistCard extends StatelessWidget {
                         updatedAt: playlist.updatedAt,
                       ),
                       httpHeaders: FeiNiuApiClient.imageAuthHeaders(),
+                      memCacheWidth: memoryCacheSize,
+                      memCacheHeight: memoryCacheSize,
                       fit: BoxFit.cover,
                       placeholder: (_, _) => _placeholder(context),
                       errorWidget: (_, _, _) => _placeholder(context),
@@ -538,4 +542,3 @@ class _LargeEmpty extends StatelessWidget {
     );
   }
 }
-

--- a/lib/pages/library/albums_page.dart
+++ b/lib/pages/library/albums_page.dart
@@ -243,11 +243,16 @@ class _AlbumsPageState extends State<AlbumsPage>
     if (groups.isEmpty || !mounted) return;
     final api = FeiNiuApiClient.instance;
     final headers = FeiNiuApiClient.imageAuthHeaders();
+    final memoryCacheSize = coverMemoryCacheDimensionOf(context, 160);
     for (final g in groups.take(count)) {
       if (g.coverId != null && g.coverId!.isNotEmpty) {
         final url = api.coverUrl(g.coverId!, size: FeiNiuApiClient.coverRequestSize, updatedAt: null);
         unawaited(precacheImage(
-          CachedNetworkImageProvider(url, headers: headers),
+          ResizeImage.resizeIfNeeded(
+            memoryCacheSize,
+            memoryCacheSize,
+            CachedNetworkImageProvider(url, headers: headers),
+          ),
           context,
         ));
       }
@@ -704,6 +709,7 @@ class _AlbumCover extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final memoryCacheSize = coverMemoryCacheDimensionOf(context, size);
     if (coverId == null || coverId!.isEmpty) {
       return SizedBox(
         width: size,
@@ -734,6 +740,8 @@ class _AlbumCover extends StatelessWidget {
         httpHeaders: _authHeaders(),
         width: size,
         height: size,
+        memCacheWidth: memoryCacheSize,
+        memCacheHeight: memoryCacheSize,
         fit: BoxFit.cover,
         placeholder: (context, url) =>
             SizedBox(width: size, height: size, child: placeholder),

--- a/lib/pages/library/artists_page.dart
+++ b/lib/pages/library/artists_page.dart
@@ -160,11 +160,16 @@ class _ArtistsPageState extends State<ArtistsPage>
     if (groups.isEmpty || !mounted) return;
     final api = FeiNiuApiClient.instance;
     final headers = FeiNiuApiClient.imageAuthHeaders();
+    final memoryCacheSize = coverMemoryCacheDimensionOf(context, 160);
     for (final g in groups.take(count)) {
       if (g.artist.coverId != null && g.artist.coverId!.isNotEmpty) {
         final url = api.coverUrl(g.artist.coverId!, size: FeiNiuApiClient.coverRequestSize, updatedAt: null);
         unawaited(precacheImage(
-          CachedNetworkImageProvider(url, headers: headers),
+          ResizeImage.resizeIfNeeded(
+            memoryCacheSize,
+            memoryCacheSize,
+            CachedNetworkImageProvider(url, headers: headers),
+          ),
           context,
         ));
       }
@@ -465,6 +470,7 @@ class _ArtistAvatar extends StatelessWidget {
   Widget build(BuildContext context) {
     final radius = size / 2;
     final initial = name.isNotEmpty ? name.characters.first : '?';
+    final memoryCacheSize = coverMemoryCacheDimensionOf(context, size);
 
     if (coverId != null && coverId!.isNotEmpty) {
       final coverUrl = FeiNiuApiClient.instance.coverUrl(
@@ -474,9 +480,13 @@ class _ArtistAvatar extends StatelessWidget {
       // 有封面图：完整显示图片，不叠加首字母
       return CircleAvatar(
         radius: radius,
-        backgroundImage: CachedNetworkImageProvider(
-          coverUrl,
-          headers: FeiNiuApiClient.imageAuthHeaders(),
+        backgroundImage: ResizeImage.resizeIfNeeded(
+          memoryCacheSize,
+          memoryCacheSize,
+          CachedNetworkImageProvider(
+            coverUrl,
+            headers: FeiNiuApiClient.imageAuthHeaders(),
+          ),
         ),
       );
     }

--- a/lib/pages/library/playlists_page.dart
+++ b/lib/pages/library/playlists_page.dart
@@ -108,12 +108,17 @@ class _PlaylistsPageState extends State<PlaylistsPage>
     if (items.isEmpty || !mounted) return;
     final api = FeiNiuApiClient.instance;
     final headers = FeiNiuApiClient.imageAuthHeaders();
+    final memoryCacheSize = coverMemoryCacheDimensionOf(context, 160);
     for (final p in items.take(count)) {
       if (p.coverId != null && p.coverId!.isNotEmpty) {
         final url = api.coverUrl(p.coverId!, size: FeiNiuApiClient.coverRequestSize, updatedAt: p.updatedAt);
         unawaited(
           precacheImage(
-            CachedNetworkImageProvider(url, headers: headers),
+            ResizeImage.resizeIfNeeded(
+              memoryCacheSize,
+              memoryCacheSize,
+              CachedNetworkImageProvider(url, headers: headers),
+            ),
             context,
           ),
         );
@@ -892,6 +897,7 @@ class _PlaylistCover extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final memoryCacheSize = coverMemoryCacheDimensionOf(context, size);
     if (coverId == null || coverId!.isEmpty) {
       return SizedBox(
         width: size,
@@ -922,6 +928,8 @@ class _PlaylistCover extends StatelessWidget {
         httpHeaders: _authHeaders(),
         width: size,
         height: size,
+        memCacheWidth: memoryCacheSize,
+        memCacheHeight: memoryCacheSize,
         fit: BoxFit.cover,
         placeholder: (context, url) =>
             SizedBox(width: size, height: size, child: placeholder),

--- a/lib/pages/player/player_page.dart
+++ b/lib/pages/player/player_page.dart
@@ -180,9 +180,7 @@ class _PlayerPageState extends State<PlayerPage>
           },
           child: Stack(
             children: [
-              RepaintBoundary(
-                child: PlayerBackground(songSignal: _player.currentSongSignal),
-              ),
+              PlayerBackground(songSignal: _player.currentSongSignal),
               PlayerTheme(
                 child: ValueListenableBuilder<PlayerStylePreset>(
                   valueListenable: PlayerStyleSettings.stylePreset,

--- a/lib/pages/player/widgets/player_background.dart
+++ b/lib/pages/player/widgets/player_background.dart
@@ -13,12 +13,10 @@ import '../../../app/state/song_state.dart';
 import '../../../app/utils/route_visibility.dart';
 
 @visibleForTesting
-int dynamicGradientFramesPerSecond(TargetPlatform platform) {
-  return switch (platform) {
-    TargetPlatform.macOS || TargetPlatform.windows || TargetPlatform.linux => 8,
-    _ => 15,
-  };
-}
+const int dynamicGradientFramesPerSecond = 8;
+
+@visibleForTesting
+const int dynamicGradientTextureDimension = 640;
 
 class PlayerBackgroundSettings {
   static const String _prefsPlaybackThemeMode = 'setting_playback_theme_mode';
@@ -417,6 +415,9 @@ class _DynamicGradientBackgroundState extends State<_DynamicGradientBackground>
 
   late AnimationController _controller;
   late final int _phaseSteps;
+  ui.Image? _texture;
+  bool? _textureIsDark;
+  int _textureGeneration = 0;
 
   @override
   AnimationController get visibilityController => _controller;
@@ -424,36 +425,117 @@ class _DynamicGradientBackgroundState extends State<_DynamicGradientBackground>
   @override
   void initState() {
     super.initState();
-    _phaseSteps =
-        _animationDuration.inSeconds *
-        dynamicGradientFramesPerSecond(defaultTargetPlatform);
+    _phaseSteps = _animationDuration.inSeconds * dynamicGradientFramesPerSecond;
     // One slow loop drives all blob drift; long period keeps it calm/premium.
     _controller = AnimationController(vsync: this, duration: _animationDuration)
       ..repeat();
   }
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    if (_textureIsDark != isDark) {
+      _textureIsDark = isDark;
+      _regenerateTexture(isDark);
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant _DynamicGradientBackground oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.baseColor != widget.baseColor ||
+        oldWidget.saturation != widget.saturation ||
+        oldWidget.hueShift != widget.hueShift) {
+      _regenerateTexture(
+        _textureIsDark ?? Theme.of(context).brightness == Brightness.dark,
+      );
+    }
+  }
+
+  Future<void> _regenerateTexture(bool isDark) async {
+    final generation = ++_textureGeneration;
+    final recorder = ui.PictureRecorder();
+    final canvas = Canvas(recorder);
+    final size = Size.square(dynamicGradientTextureDimension.toDouble());
+    _AuroraPainter(
+      t: 0.18,
+      base: widget.baseColor,
+      saturation: widget.saturation,
+      hueShift: widget.hueShift,
+      isDark: isDark,
+    ).paint(canvas, size);
+    final picture = recorder.endRecording();
+    late final ui.Image image;
+    try {
+      image = await picture.toImage(
+        dynamicGradientTextureDimension,
+        dynamicGradientTextureDimension,
+      );
+    } catch (error) {
+      if (kDebugMode) {
+        debugPrint('Failed to create player background texture: $error');
+      }
+      return;
+    } finally {
+      picture.dispose();
+    }
+    if (!mounted || generation != _textureGeneration) {
+      image.dispose();
+      return;
+    }
+    final previous = _texture;
+    setState(() => _texture = image);
+    if (previous != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => previous.dispose());
+    }
+  }
+
+  @override
   void dispose() {
+    _textureGeneration++;
+    _texture?.dispose();
     _controller.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    return AnimatedBuilder(
-      animation: _controller,
-      builder: (context, _) {
-        final t =
-            (_controller.value * _phaseSteps).floorToDouble() / _phaseSteps;
-        return CustomPaint(
-          size: Size.infinite,
-          painter: _AuroraPainter(
-            t: t,
-            base: widget.baseColor,
-            saturation: widget.saturation,
-            hueShift: widget.hueShift,
-            isDark: isDark,
+    final texture = _texture;
+    if (texture == null) {
+      return ColoredBox(color: widget.baseColor);
+    }
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return ClipRect(
+          child: AnimatedBuilder(
+            animation: _controller,
+            child: RepaintBoundary(
+              child: SizedBox.expand(
+                child: RawImage(
+                  image: texture,
+                  fit: BoxFit.cover,
+                  filterQuality: FilterQuality.low,
+                ),
+              ),
+            ),
+            builder: (context, child) {
+              final t =
+                  (_controller.value * _phaseSteps).floorToDouble() /
+                  _phaseSteps;
+              final angle = 0.025 * math.sin(2 * math.pi * t);
+              final offset = Offset(
+                constraints.maxWidth * 0.025 * math.sin(2 * math.pi * t),
+                constraints.maxHeight * 0.025 * math.cos(2 * math.pi * t),
+              );
+              return Transform.translate(
+                offset: offset,
+                child: Transform.rotate(
+                  angle: angle,
+                  child: Transform.scale(scale: 1.12, child: child),
+                ),
+              );
+            },
           ),
         );
       },

--- a/lib/pages/player/widgets/player_background.dart
+++ b/lib/pages/player/widgets/player_background.dart
@@ -603,10 +603,7 @@ class _DynamicGradientBackgroundState extends State<_DynamicGradientBackground>
                       fit: StackFit.expand,
                       children: [
                         if (_previousTexture != null)
-                          Opacity(
-                            opacity: 1 - _colorTransitionController.value,
-                            child: _textureWidget(_previousTexture!),
-                          ),
+                          _textureWidget(_previousTexture!),
                         Opacity(
                           opacity: _previousTexture == null
                               ? 1

--- a/lib/pages/player/widgets/player_background.dart
+++ b/lib/pages/player/widgets/player_background.dart
@@ -13,10 +13,15 @@ import '../../../app/state/song_state.dart';
 import '../../../app/utils/route_visibility.dart';
 
 @visibleForTesting
-const int dynamicGradientFramesPerSecond = 8;
+const int dynamicGradientTextureDimension = 640;
 
 @visibleForTesting
-const int dynamicGradientTextureDimension = 640;
+const int dynamicGradientMaxResidentTextures = 2;
+
+@visibleForTesting
+const Duration dynamicGradientColorTransitionDuration = Duration(
+  milliseconds: 1500,
+);
 
 class PlayerBackgroundSettings {
   static const String _prefsPlaybackThemeMode = 'setting_playback_theme_mode';
@@ -270,12 +275,12 @@ class _PlayerBackgroundState extends State<PlayerBackground> {
   }
 
   Future<Color?> _computeDominantColor(String coverId) async {
+    final dio = Dio();
     try {
       final api = FeiNiuApiClient.instance;
       // 仅用于取主色调的下采样（非显示），刻意用小图 40px 节省带宽与解码；
       // 不参与封面显示的缓存复用。
       final url = api.coverUrl(coverId, size: 40);
-      final dio = Dio();
       final response = await dio.get(
         url,
         options: Options(
@@ -284,9 +289,11 @@ class _PlayerBackgroundState extends State<PlayerBackground> {
         ),
       );
       final bytes = response.data as Uint8List;
-      return averageImageColor(bytes);
+      return await averageImageColor(bytes);
     } catch (_) {
       return null;
+    } finally {
+      dio.close(force: true);
     }
   }
 }
@@ -300,25 +307,33 @@ Future<Color?> averageImageColor(Uint8List bytes) async {
     targetWidth: 40,
     targetHeight: 40,
   );
-  final frame = await codec.getNextFrame();
-  final image = frame.image;
-  final data = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
-  if (data == null) return null;
-  final list = data.buffer.asUint8List();
-  int r = 0;
-  int g = 0;
-  int b = 0;
-  int count = 0;
-  for (var i = 0; i + 3 < list.length; i += 4) {
-    final a = list[i + 3];
-    if (a < 10) continue;
-    r += list[i];
-    g += list[i + 1];
-    b += list[i + 2];
-    count += 1;
+  try {
+    final frame = await codec.getNextFrame();
+    final image = frame.image;
+    try {
+      final data = await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+      if (data == null) return null;
+      final list = data.buffer.asUint8List();
+      int r = 0;
+      int g = 0;
+      int b = 0;
+      int count = 0;
+      for (var i = 0; i + 3 < list.length; i += 4) {
+        final a = list[i + 3];
+        if (a < 10) continue;
+        r += list[i];
+        g += list[i + 1];
+        b += list[i + 2];
+        count += 1;
+      }
+      if (count == 0) return null;
+      return Color.fromARGB(255, r ~/ count, g ~/ count, b ~/ count);
+    } finally {
+      image.dispose();
+    }
+  } finally {
+    codec.dispose();
   }
-  if (count == 0) return null;
-  return Color.fromARGB(255, r ~/ count, g ~/ count, b ~/ count);
 }
 
 /// Dominant color of a bundled asset image, for previews that want the aurora to
@@ -326,7 +341,7 @@ Future<Color?> averageImageColor(Uint8List bytes) async {
 Future<Color?> dominantColorFromAsset(String assetPath) async {
   try {
     final data = await rootBundle.load(assetPath);
-    return averageImageColor(data.buffer.asUint8List());
+    return await averageImageColor(data.buffer.asUint8List());
   } catch (_) {
     return null;
   }
@@ -410,12 +425,13 @@ class _DynamicGradientBackground extends StatefulWidget {
 }
 
 class _DynamicGradientBackgroundState extends State<_DynamicGradientBackground>
-    with SingleTickerProviderStateMixin, AppRouteVisibilityMixin {
+    with TickerProviderStateMixin, AppRouteVisibilityMixin {
   static const Duration _animationDuration = Duration(seconds: 22);
 
-  late AnimationController _controller;
-  late final int _phaseSteps;
+  late final AnimationController _controller;
+  late final AnimationController _colorTransitionController;
   ui.Image? _texture;
+  ui.Image? _previousTexture;
   bool? _textureIsDark;
   int _textureGeneration = 0;
 
@@ -423,12 +439,26 @@ class _DynamicGradientBackgroundState extends State<_DynamicGradientBackground>
   AnimationController get visibilityController => _controller;
 
   @override
+  Iterable<AnimationController> get additionalVisibilityControllers => [
+    _colorTransitionController,
+  ];
+
+  @override
   void initState() {
     super.initState();
-    _phaseSteps = _animationDuration.inSeconds * dynamicGradientFramesPerSecond;
     // One slow loop drives all blob drift; long period keeps it calm/premium.
     _controller = AnimationController(vsync: this, duration: _animationDuration)
       ..repeat();
+    _colorTransitionController =
+        AnimationController(
+          vsync: this,
+          duration: dynamicGradientColorTransitionDuration,
+          value: 1,
+        )..addStatusListener((status) {
+          if (status == AnimationStatus.completed) {
+            _disposePreviousTexture();
+          }
+        });
   }
 
   @override
@@ -437,7 +467,7 @@ class _DynamicGradientBackgroundState extends State<_DynamicGradientBackground>
     final isDark = Theme.of(context).brightness == Brightness.dark;
     if (_textureIsDark != isDark) {
       _textureIsDark = isDark;
-      _regenerateTexture(isDark);
+      _regenerateTexture(isDark, animateTransition: _texture != null);
     }
   }
 
@@ -447,13 +477,18 @@ class _DynamicGradientBackgroundState extends State<_DynamicGradientBackground>
     if (oldWidget.baseColor != widget.baseColor ||
         oldWidget.saturation != widget.saturation ||
         oldWidget.hueShift != widget.hueShift) {
+      final baseColorChanged = oldWidget.baseColor != widget.baseColor;
       _regenerateTexture(
         _textureIsDark ?? Theme.of(context).brightness == Brightness.dark,
+        animateTransition: baseColorChanged,
       );
     }
   }
 
-  Future<void> _regenerateTexture(bool isDark) async {
+  Future<void> _regenerateTexture(
+    bool isDark, {
+    bool animateTransition = false,
+  }) async {
     final generation = ++_textureGeneration;
     final recorder = ui.PictureRecorder();
     final canvas = Canvas(recorder);
@@ -484,17 +519,55 @@ class _DynamicGradientBackgroundState extends State<_DynamicGradientBackground>
       image.dispose();
       return;
     }
-    final previous = _texture;
-    setState(() => _texture = image);
-    if (previous != null) {
-      WidgetsBinding.instance.addPostFrameCallback((_) => previous.dispose());
+    final current = _texture;
+    if (animateTransition && current != null) {
+      final superseded = _previousTexture;
+      setState(() {
+        _previousTexture = current;
+        _texture = image;
+      });
+      _colorTransitionController.forward(from: 0);
+      if (superseded != null) {
+        WidgetsBinding.instance.addPostFrameCallback(
+          (_) => superseded.dispose(),
+        );
+      }
+    } else {
+      final previous = _previousTexture;
+      _previousTexture = null;
+      setState(() => _texture = image);
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        previous?.dispose();
+        current?.dispose();
+      });
+    }
+  }
+
+  void _disposePreviousTexture() {
+    final previous = _previousTexture;
+    if (previous == null) return;
+    if (mounted) {
+      setState(() => _previousTexture = null);
+    } else {
+      _previousTexture = null;
+    }
+    WidgetsBinding.instance.addPostFrameCallback((_) => previous.dispose());
+  }
+
+  @override
+  void resumeVisibilityAnimation() {
+    _controller.repeat();
+    if (_colorTransitionController.value < 1) {
+      _colorTransitionController.forward();
     }
   }
 
   @override
   void dispose() {
     _textureGeneration++;
+    _previousTexture?.dispose();
     _texture?.dispose();
+    _colorTransitionController.dispose();
     _controller.dispose();
     super.dispose();
   }
@@ -509,20 +582,12 @@ class _DynamicGradientBackgroundState extends State<_DynamicGradientBackground>
       builder: (context, constraints) {
         return ClipRect(
           child: AnimatedBuilder(
-            animation: _controller,
-            child: RepaintBoundary(
-              child: SizedBox.expand(
-                child: RawImage(
-                  image: texture,
-                  fit: BoxFit.cover,
-                  filterQuality: FilterQuality.low,
-                ),
-              ),
-            ),
+            animation: Listenable.merge([
+              _controller,
+              _colorTransitionController,
+            ]),
             builder: (context, child) {
-              final t =
-                  (_controller.value * _phaseSteps).floorToDouble() /
-                  _phaseSteps;
+              final t = _controller.value;
               final angle = 0.025 * math.sin(2 * math.pi * t);
               final offset = Offset(
                 constraints.maxWidth * 0.025 * math.sin(2 * math.pi * t),
@@ -532,13 +597,41 @@ class _DynamicGradientBackgroundState extends State<_DynamicGradientBackground>
                 offset: offset,
                 child: Transform.rotate(
                   angle: angle,
-                  child: Transform.scale(scale: 1.12, child: child),
+                  child: Transform.scale(
+                    scale: 1.12,
+                    child: Stack(
+                      fit: StackFit.expand,
+                      children: [
+                        if (_previousTexture != null)
+                          Opacity(
+                            opacity: 1 - _colorTransitionController.value,
+                            child: _textureWidget(_previousTexture!),
+                          ),
+                        Opacity(
+                          opacity: _previousTexture == null
+                              ? 1
+                              : _colorTransitionController.value,
+                          child: _textureWidget(texture),
+                        ),
+                      ],
+                    ),
+                  ),
                 ),
               );
             },
           ),
         );
       },
+    );
+  }
+
+  Widget _textureWidget(ui.Image image) {
+    return RepaintBoundary(
+      child: RawImage(
+        image: image,
+        fit: BoxFit.cover,
+        filterQuality: FilterQuality.low,
+      ),
     );
   }
 }

--- a/lib/pages/player/widgets/player_background.dart
+++ b/lib/pages/player/widgets/player_background.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 import 'dart:ui' as ui;
 
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -10,6 +11,14 @@ import 'package:signals_flutter/signals_flutter.dart' hide computed;
 import '../../../app/services/feiniu/api_client.dart';
 import '../../../app/state/song_state.dart';
 import '../../../app/utils/route_visibility.dart';
+
+@visibleForTesting
+int dynamicGradientFramesPerSecond(TargetPlatform platform) {
+  return switch (platform) {
+    TargetPlatform.macOS || TargetPlatform.windows || TargetPlatform.linux => 8,
+    _ => 15,
+  };
+}
 
 class PlayerBackgroundSettings {
   static const String _prefsPlaybackThemeMode = 'setting_playback_theme_mode';
@@ -404,12 +413,10 @@ class _DynamicGradientBackground extends StatefulWidget {
 
 class _DynamicGradientBackgroundState extends State<_DynamicGradientBackground>
     with SingleTickerProviderStateMixin, AppRouteVisibilityMixin {
-  // ~30fps over the 22s loop. Quantizing the animation phase lets the painter's
-  // shouldRepaint skip the full-screen multi-shader repaint between steps, while
-  // the very slow drift stays visually smooth.
-  static const int _phaseSteps = 22 * 30;
+  static const Duration _animationDuration = Duration(seconds: 22);
 
   late AnimationController _controller;
+  late final int _phaseSteps;
 
   @override
   AnimationController get visibilityController => _controller;
@@ -417,11 +424,12 @@ class _DynamicGradientBackgroundState extends State<_DynamicGradientBackground>
   @override
   void initState() {
     super.initState();
+    _phaseSteps =
+        _animationDuration.inSeconds *
+        dynamicGradientFramesPerSecond(defaultTargetPlatform);
     // One slow loop drives all blob drift; long period keeps it calm/premium.
-    _controller = AnimationController(
-      vsync: this,
-      duration: const Duration(seconds: 22),
-    )..repeat();
+    _controller = AnimationController(vsync: this, duration: _animationDuration)
+      ..repeat();
   }
 
   @override
@@ -433,24 +441,22 @@ class _DynamicGradientBackgroundState extends State<_DynamicGradientBackground>
   @override
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
-    return RepaintBoundary(
-      child: AnimatedBuilder(
-        animation: _controller,
-        builder: (context, _) {
-          final t =
-              (_controller.value * _phaseSteps).floorToDouble() / _phaseSteps;
-          return CustomPaint(
-            size: Size.infinite,
-            painter: _AuroraPainter(
-              t: t,
-              base: widget.baseColor,
-              saturation: widget.saturation,
-              hueShift: widget.hueShift,
-              isDark: isDark,
-            ),
-          );
-        },
-      ),
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, _) {
+        final t =
+            (_controller.value * _phaseSteps).floorToDouble() / _phaseSteps;
+        return CustomPaint(
+          size: Size.infinite,
+          painter: _AuroraPainter(
+            t: t,
+            base: widget.baseColor,
+            saturation: widget.saturation,
+            hueShift: widget.hueShift,
+            isDark: isDark,
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/pages/player/widgets/player_bottom_panel.dart
+++ b/lib/pages/player/widgets/player_bottom_panel.dart
@@ -645,9 +645,7 @@ class _PlayerSheetView extends StatelessWidget {
         borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
         child: Stack(
           children: [
-            RepaintBoundary(
-              child: PlayerBackground(songSignal: player.currentSongSignal),
-            ),
+            PlayerBackground(songSignal: player.currentSongSignal),
             RepaintBoundary(
               child: ValueListenableBuilder<bool>(
                 valueListenable: AppBackgroundSettings.panelBlurEnabled,

--- a/lib/pages/search/search_page.dart
+++ b/lib/pages/search/search_page.dart
@@ -260,6 +260,7 @@ class _SearchPageState extends State<SearchPage> {
   }
 
   Widget _buildResults(ThemeData theme, bool isDark) {
+    final listCoverCacheSize = coverMemoryCacheDimensionOf(context, 48);
     final q = _query.trim();
 
     if (q.isEmpty) {
@@ -358,6 +359,8 @@ class _SearchPageState extends State<SearchPage> {
                             httpHeaders: FeiNiuApiClient.imageAuthHeaders(),
                             width: 48,
                             height: 48,
+                            memCacheWidth: listCoverCacheSize,
+                            memCacheHeight: listCoverCacheSize,
                             fit: BoxFit.cover,
                             errorWidget: (_, _, _) => _albumPlaceholder(theme),
                           ),
@@ -400,9 +403,13 @@ class _SearchPageState extends State<SearchPage> {
                   leading: CircleAvatar(
                     radius: 24,
                     backgroundImage: coverUrl != null
-                        ? CachedNetworkImageProvider(
-                            coverUrl,
-                            headers: FeiNiuApiClient.imageAuthHeaders(),
+                        ? ResizeImage.resizeIfNeeded(
+                            listCoverCacheSize,
+                            listCoverCacheSize,
+                            CachedNetworkImageProvider(
+                              coverUrl,
+                              headers: FeiNiuApiClient.imageAuthHeaders(),
+                            ),
                           )
                         : null,
                     child: coverUrl == null

--- a/lib/pages/songs/songs_page.dart
+++ b/lib/pages/songs/songs_page.dart
@@ -128,12 +128,18 @@ class _SongsPageState extends State<SongsPage>
     if (songs.isEmpty || !mounted) return;
     final api = FeiNiuApiClient.instance;
     final headers = FeiNiuApiClient.imageAuthHeaders();
+    final memoryCacheSize = coverMemoryCacheDimensionOf(context, 48);
     int loaded = 0, skipped = 0;
     for (final song in songs.take(count)) {
       if (song.coverId != null && song.coverId!.isNotEmpty) {
         final url = api.coverUrl(song.coverId!, size: FeiNiuApiClient.coverRequestSize, updatedAt: song.updatedAt);
-        unawaited(precacheImage(
+        final provider = ResizeImage.resizeIfNeeded(
+          memoryCacheSize,
+          memoryCacheSize,
           CachedNetworkImageProvider(url, headers: headers),
+        );
+        unawaited(precacheImage(
+          provider,
           context,
         ).then((_) => loaded++).catchError((e) {
           debugPrint('[SongsPage] cover precache failed song=${song.title} coverId=${song.coverId}: $e');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.6.1+1
+version: 1.6.1+2
 
 environment:
   sdk: ^3.10.8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.6.3+4
+version: 1.6.3+5
 
 environment:
   sdk: ^3.10.8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.6.1+2
+version: 1.6.2+3
 
 environment:
   sdk: ^3.10.8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.6.2+3
+version: 1.6.3+4
 
 environment:
   sdk: ^3.10.8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.6.3+6
+version: 1.6.2+1
 
 environment:
   sdk: ^3.10.8

--- a/test/cover_image_cache_test.dart
+++ b/test/cover_image_cache_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:feiniu_music/components/common/cover_image_cache.dart';
+
+void main() {
+  group('coverMemoryCacheDimension', () {
+    test('uses logical size multiplied by device pixel ratio', () {
+      expect(
+        coverMemoryCacheDimension(logicalSize: 48, devicePixelRatio: 2),
+        96,
+      );
+    });
+
+    test('rounds up fractional physical pixels', () {
+      expect(
+        coverMemoryCacheDimension(logicalSize: 47.5, devicePixelRatio: 2.5),
+        119,
+      );
+    });
+
+    test('caps decoded covers at the canonical source dimension', () {
+      expect(
+        coverMemoryCacheDimension(logicalSize: 600, devicePixelRatio: 2),
+        800,
+      );
+    });
+
+    test('returns a safe minimum for invalid dimensions', () {
+      expect(coverMemoryCacheDimension(logicalSize: 0, devicePixelRatio: 2), 1);
+    });
+  });
+}

--- a/test/gradient_preview_test.dart
+++ b/test/gradient_preview_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' as ui;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -6,29 +8,13 @@ import 'package:signals/signals.dart';
 import 'package:feiniu_music/app/state/song_state.dart';
 import 'package:feiniu_music/pages/player/widgets/player_background.dart';
 
-double? _auroraSaturation(WidgetTester tester) =>
-    _auroraField(tester, 'saturation');
-double? _auroraHueShift(WidgetTester tester) =>
-    _auroraField(tester, 'hueShift');
-
-double? _auroraField(WidgetTester tester, String field) {
-  for (final cp in tester.widgetList<CustomPaint>(find.byType(CustomPaint))) {
-    final painter = cp.painter;
-    if (painter == null) continue;
-    if (painter.runtimeType.toString().contains('Aurora')) {
-      final value = field == 'saturation'
-          ? (painter as dynamic).saturation
-          : (painter as dynamic).hueShift;
-      return value as double;
-    }
-  }
-  return null;
-}
+ui.Image? _backgroundTexture(WidgetTester tester) =>
+    tester.widget<RawImage>(find.byType(RawImage)).image;
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('dynamic aurora preview repaints when saturation changes', (
+  testWidgets('dynamic aurora regenerates its bounded texture when tuned', (
     tester,
   ) async {
     SharedPreferences.setMockInitialValues({});
@@ -48,25 +34,24 @@ void main() {
     );
     await tester.pump(const Duration(milliseconds: 50));
 
-    expect(_auroraSaturation(tester), isNotNull, reason: '动态流光开启时应渲染极光画笔');
-    expect(_auroraSaturation(tester), closeTo(1.0, 0.0001));
+    expect(find.byType(RawImage), findsOneWidget);
+    final initialTexture = _backgroundTexture(tester);
+    expect(initialTexture, isNotNull, reason: '动态流光开启时应生成有界背景纹理');
 
     PlayerBackgroundSettings.saturation.value = 2.0;
+    await tester.pump();
     await tester.pump(const Duration(milliseconds: 50));
 
-    expect(
-      _auroraSaturation(tester),
-      closeTo(2.0, 0.0001),
-      reason: '改变 saturation 后画笔应收到新值（接线是否生效）',
-    );
+    final saturatedTexture = _backgroundTexture(tester);
+    expect(saturatedTexture, isNotNull);
+    expect(saturatedTexture, isNot(same(initialTexture)));
 
     PlayerBackgroundSettings.hueShift.value = 120.0;
+    await tester.pump();
     await tester.pump(const Duration(milliseconds: 50));
 
-    expect(
-      _auroraHueShift(tester),
-      closeTo(120.0, 0.0001),
-      reason: '改变 hueShift 后画笔应收到新值',
-    );
+    final shiftedTexture = _backgroundTexture(tester);
+    expect(shiftedTexture, isNotNull);
+    expect(shiftedTexture, isNot(same(saturatedTexture)));
   });
 }

--- a/test/media_kit_engine_test.dart
+++ b/test/media_kit_engine_test.dart
@@ -4,6 +4,42 @@ import 'package:feiniu_music/app/services/player/media_kit_engine.dart';
 import 'package:feiniu_music/app/services/player/player_engine.dart';
 
 void main() {
+  group('configureMediaKitDesktopAudioOnly', () {
+    test('禁用 mpv 磁盘缓存、内嵌封面显示和视频轨', () async {
+      final applied = <String, String>{};
+
+      await configureMediaKitDesktopAudioOnly(
+        setProperty: (property, value) async {
+          applied[property] = value;
+        },
+      );
+
+      expect(applied, {
+        'cache-on-disk': 'no',
+        'audio-display': 'no',
+        'vid': 'no',
+      });
+    });
+
+    test('单个 mpv 属性失败时继续应用其余保护项', () async {
+      final attempted = <String>[];
+      final errors = <String>[];
+
+      await configureMediaKitDesktopAudioOnly(
+        setProperty: (property, value) async {
+          attempted.add(property);
+          if (property == 'audio-display') {
+            throw UnsupportedError(property);
+          }
+        },
+        onError: (property, error) => errors.add(property),
+      );
+
+      expect(attempted, ['cache-on-disk', 'audio-display', 'vid']);
+      expect(errors, ['audio-display']);
+    });
+  });
+
   group('mediaKitCompletedPlaylistIndex', () {
     test('completed 回调使用已交付索引而不是抢跑到下一首的原生索引', () {
       expect(

--- a/test/media_kit_engine_test.dart
+++ b/test/media_kit_engine_test.dart
@@ -163,10 +163,7 @@ void main() {
         const Duration(minutes: 53),
       );
       expect(
-        normalizeCroppedPosition(
-          const Duration(minutes: 53),
-          Duration.zero,
-        ),
+        normalizeCroppedPosition(const Duration(minutes: 53), Duration.zero),
         const Duration(minutes: 53),
       );
     });

--- a/test/player_background_performance_test.dart
+++ b/test/player_background_performance_test.dart
@@ -1,0 +1,18 @@
+import 'package:feiniu_music/pages/player/widgets/player_background.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('dynamicGradientFramesPerSecond', () {
+    test('limits desktop platforms to 8 frames per second', () {
+      expect(dynamicGradientFramesPerSecond(TargetPlatform.macOS), 8);
+      expect(dynamicGradientFramesPerSecond(TargetPlatform.windows), 8);
+      expect(dynamicGradientFramesPerSecond(TargetPlatform.linux), 8);
+    });
+
+    test('keeps mobile platforms smoother', () {
+      expect(dynamicGradientFramesPerSecond(TargetPlatform.android), 15);
+      expect(dynamicGradientFramesPerSecond(TargetPlatform.iOS), 15);
+    });
+  });
+}

--- a/test/player_background_performance_test.dart
+++ b/test/player_background_performance_test.dart
@@ -22,5 +22,14 @@ void main() {
       expect(dynamicGradientMaxResidentTextures, 2);
       expect(rgbaBytes, lessThan(4 * 1024 * 1024));
     });
+
+    test('crossfade keeps the previous texture opaque', () {
+      for (final incomingOpacity in [0.0, 0.25, 0.5, 0.75, 1.0]) {
+        const previousOpacity = 1.0;
+        final compositeOpacity =
+            incomingOpacity + previousOpacity * (1 - incomingOpacity);
+        expect(compositeOpacity, 1.0);
+      }
+    });
   });
 }

--- a/test/player_background_performance_test.dart
+++ b/test/player_background_performance_test.dart
@@ -1,18 +1,16 @@
 import 'package:feiniu_music/pages/player/widgets/player_background.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  group('dynamicGradientFramesPerSecond', () {
-    test('limits desktop platforms to 8 frames per second', () {
-      expect(dynamicGradientFramesPerSecond(TargetPlatform.macOS), 8);
-      expect(dynamicGradientFramesPerSecond(TargetPlatform.windows), 8);
-      expect(dynamicGradientFramesPerSecond(TargetPlatform.linux), 8);
+  group('dynamic gradient resource limits', () {
+    test('uses the same low animation rate on every platform', () {
+      expect(dynamicGradientFramesPerSecond, 8);
     });
 
-    test('keeps mobile platforms smoother', () {
-      expect(dynamicGradientFramesPerSecond(TargetPlatform.android), 15);
-      expect(dynamicGradientFramesPerSecond(TargetPlatform.iOS), 15);
+    test('keeps the reusable RGBA texture below two megabytes', () {
+      const rgbaBytes =
+          dynamicGradientTextureDimension * dynamicGradientTextureDimension * 4;
+      expect(rgbaBytes, lessThan(2 * 1024 * 1024));
     });
   });
 }

--- a/test/player_background_performance_test.dart
+++ b/test/player_background_performance_test.dart
@@ -3,14 +3,24 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('dynamic gradient resource limits', () {
-    test('uses the same low animation rate on every platform', () {
-      expect(dynamicGradientFramesPerSecond, 8);
-    });
+    test(
+      'uses a long color transition instead of abrupt texture replacement',
+      () {
+        expect(
+          dynamicGradientColorTransitionDuration,
+          const Duration(milliseconds: 1500),
+        );
+      },
+    );
 
-    test('keeps the reusable RGBA texture below two megabytes', () {
+    test('keeps both transition RGBA textures below four megabytes', () {
       const rgbaBytes =
-          dynamicGradientTextureDimension * dynamicGradientTextureDimension * 4;
-      expect(rgbaBytes, lessThan(2 * 1024 * 1024));
+          dynamicGradientTextureDimension *
+          dynamicGradientTextureDimension *
+          4 *
+          dynamicGradientMaxResidentTextures;
+      expect(dynamicGradientMaxResidentTextures, 2);
+      expect(rgbaBytes, lessThan(4 * 1024 * 1024));
     });
   });
 }


### PR DESCRIPTION
## 修改内容

- 限制封面解码尺寸，使其匹配实际显示大小，同时保留共享的网络和磁盘缓存键
- 将桌面端 media_kit 配置为纯音频播放，关闭 mpv 磁盘缓存、视频轨和内嵌封面路径
- 将逐帧绘制的动态极光背景改为有界、可复用的纹理，并及时释放已解码图像
- 播放页被其他路由覆盖时暂停背景动画和过渡动画
- 增加封面缓存尺寸、媒体播放属性和背景纹理生命周期的回归测试

## 验证结果

- `flutter test --no-pub`：499 项全部通过
- 变更文件静态分析：无问题
- Windows Release 构建及专项回归测试：[GitHub Actions #33291782663](https://github.com/qbmzc/FeiNiuMusic/actions/runs/33291782663)
- Windows 测试包：[下载 artifact](https://api.github.com/repos/qbmzc/FeiNiuMusic/actions/artifacts/9726232459/zip)

Windows 测试包已生成，仍需要在 Issue 报告者的设备上进行长时间播放和内存曲线观察。CI 已确认构建及回归测试通过，但无法替代持续运行时的驻留内存验证。

Closes #53