### PR TITLE
fix(macos): restore hidden main window

### DIFF
--- a/lib/app/services/macos_status_bar_service.dart
+++ b/lib/app/services/macos_status_bar_service.dart
@@ -20,6 +20,15 @@ String resolveMacosStatusBarText({
   return normalizedTitle;
 }
 
+/// 只有菜单栏入口可见时才允许“关闭到托盘”。否则窗口隐藏后没有可见入口
+/// 可以恢复，用户只能从活动监视器结束进程。
+bool shouldEnableMacosCloseToTray({
+  required bool closeToTrayEnabled,
+  required bool statusBarEnabled,
+}) {
+  return closeToTrayEnabled && statusBarEnabled;
+}
+
 /// macOS 菜单栏（状态栏）播放状态指示器。
 ///
 /// 仅在 macOS 平台启用：启动时在原生侧创建一个 [NSStatusItem]，
@@ -63,6 +72,7 @@ class MacosStatusBarService {
       return;
     }
     _syncVisibilityAndState();
+    _syncCloseToTray();
   }
 
   static void _syncVisibilityAndState() {
@@ -81,7 +91,13 @@ class MacosStatusBarService {
       unawaited(_connect());
       return;
     }
-    _send('setCloseToTray', CloseToTraySettings.enabled.value);
+    _send(
+      'setCloseToTray',
+      shouldEnableMacosCloseToTray(
+        closeToTrayEnabled: CloseToTraySettings.enabled.value,
+        statusBarEnabled: StatusBarSettings.enabled.value,
+      ),
+    );
   }
 
   static Future<void> _handleCall(MethodCall call) async {

--- a/lib/pages/settings/settings_page.dart
+++ b/lib/pages/settings/settings_page.dart
@@ -194,7 +194,9 @@ class _SettingsPageState extends State<SettingsPage> {
                       builder: (context, enabled, _) {
                         return AppSettingSwitchTile(
                           title: '关闭按钮隐藏到托盘',
-                          subtitle: '点击窗口关闭按钮时隐藏到系统托盘，而不是退出应用',
+                          subtitle: Platform.isMacOS
+                              ? '状态栏播放状态开启时，点击关闭按钮隐藏到菜单栏'
+                              : '点击窗口关闭按钮时隐藏到系统托盘，而不是退出应用',
                           value: enabled,
                           onChanged: (value) {
                             CloseToTraySettings.setEnabled(value);

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -21,6 +21,18 @@ class AppDelegate: FlutterAppDelegate {
     return false
   }
 
+  override func applicationShouldHandleReopen(
+    _ sender: NSApplication,
+    hasVisibleWindows flag: Bool
+  ) -> Bool {
+    // 菜单栏状态关闭或原生通道尚未同步时仍保留 Dock 恢复入口，避免主窗口
+    // 被 orderOut/close 后无法重新打开。
+    if !flag {
+      mainFlutterWindow?.makeKeyAndOrderFront(nil)
+    }
+    return true
+  }
+
   override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
     return true
   }

--- a/test/macos_status_bar_service_test.dart
+++ b/test/macos_status_bar_service_test.dart
@@ -37,4 +37,30 @@ void main() {
       );
     });
   });
+
+  group('shouldEnableMacosCloseToTray', () {
+    test('requires both close-to-tray and a visible status item', () {
+      expect(
+        shouldEnableMacosCloseToTray(
+          closeToTrayEnabled: true,
+          statusBarEnabled: true,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldEnableMacosCloseToTray(
+          closeToTrayEnabled: true,
+          statusBarEnabled: false,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldEnableMacosCloseToTray(
+          closeToTrayEnabled: false,
+          statusBarEnabled: true,
+        ),
+        isFalse,
+      );
+    });
+  });
 }


### PR DESCRIPTION
## 问题

在 macOS 上同时启用关闭按钮隐藏到托盘、关闭状态栏播放状态后，关闭主窗口会失去可见的恢复入口。

## 修复

- 仅在 macOS 状态栏入口可见时启用关闭到托盘
- 状态栏开关变化时同步原生关闭行为
- 点击 Dock 图标时恢复隐藏的主窗口
- 更新 macOS 设置说明并补充策略测试

Windows 继续沿用原有系统托盘和关闭到托盘逻辑，不受这次联动影响。

## 验证

- flutter test test/macos_status_bar_service_test.dart test/settings_close_to_tray_state_test.dart
- flutter analyze lib/app/services/macos_status_bar_service.dart lib/pages/settings/settings_page.dart test/macos_status_bar_service_test.dart
- macOS 实机验证：隐藏后点击 Dock 图标可恢复主窗口