### PR TITLE
fix(android): preserve songs sort when re-entering

### DIFF
--- a/lib/pages/home/home_page.dart
+++ b/lib/pages/home/home_page.dart
@@ -565,15 +565,9 @@ class _HomePageState extends State<HomePage>
   }
 
   void _openSongsPage() {
-    // 从首页「最新歌曲」进入：一次性按创建时间降序（不回写偏好，仅本次有效）
-    Navigator.of(context).push(
-      buildAppPageRoute<void>(
-        (_) => const SongsPage(
-          initialSortKey: 'duration',
-          initialAscending: false,
-        ),
-      ),
-    );
+    Navigator.of(
+      context,
+    ).push(buildAppPageRoute<void>((_) => const SongsPage()));
   }
 
   void _openArtistsPage() {

--- a/lib/pages/songs/songs_page.dart
+++ b/lib/pages/songs/songs_page.dart
@@ -26,12 +26,7 @@ import 'song_detail_sheet.dart';
 
 /// 音乐库（原歌曲页面）- 从飞牛 API 分页加载并展示所有歌曲
 class SongsPage extends StatefulWidget {
-  /// 一次性排序覆盖（如首页「最新歌曲」入口传入的"创建时间降序"）。
-  /// 优先级高于持久化偏好，但**不会**回写 SharedPreferences，仅本次进入有效。
-  final String? initialSortKey;
-  final bool? initialAscending;
-
-  const SongsPage({super.key, this.initialSortKey, this.initialAscending});
+  const SongsPage({super.key});
 
   @override
   State<SongsPage> createState() => _SongsPageState();
@@ -100,7 +95,7 @@ class _SongsPageState extends State<SongsPage>
     await _initialLoad;
     if (!mounted) return;
     // 底栏保留 State，重新进入时同步其他歌曲入口保存的排序。
-    await _restoreSortPrefs(applyInitialOverride: false);
+    await _restoreSortPrefs();
     if (mounted) await _loadSongs();
   }
 
@@ -369,7 +364,7 @@ class _SongsPageState extends State<SongsPage>
     await _loadMoreToTarget(target);
   }
 
-  Future<void> _restoreSortPrefs({bool applyInitialOverride = true}) async {
+  Future<void> _restoreSortPrefs() async {
     final prefs = await SharedPreferences.getInstance();
     final sortKey = prefs.getString(_prefsSortKey);
     final sortAsc = prefs.getBool(_prefsSortAsc);
@@ -379,14 +374,6 @@ class _SongsPageState extends State<SongsPage>
     }
     if (sortAsc != null) {
       _ascending.value = sortAsc;
-    }
-    // 一次性排序覆盖：仅本次进入生效，不改写持久化偏好。
-    // 首页「最新歌曲」入口要求默认按创建时间降序。
-    if (applyInitialOverride && widget.initialSortKey != null) {
-      _sortKey.value = widget.initialSortKey!;
-    }
-    if (applyInitialOverride && widget.initialAscending != null) {
-      _ascending.value = widget.initialAscending!;
     }
   }
 

--- a/lib/pages/songs/songs_page.dart
+++ b/lib/pages/songs/songs_page.dart
@@ -31,18 +31,18 @@ class SongsPage extends StatefulWidget {
   final String? initialSortKey;
   final bool? initialAscending;
 
-  const SongsPage({
-    super.key,
-    this.initialSortKey,
-    this.initialAscending,
-  });
+  const SongsPage({super.key, this.initialSortKey, this.initialAscending});
 
   @override
   State<SongsPage> createState() => _SongsPageState();
 }
 
 class _SongsPageState extends State<SongsPage>
-    with SignalsMixin, DeferredPageInitMixin, SongMultiSelectMixin, PrimaryTabRefreshMixin {
+    with
+        SignalsMixin,
+        DeferredPageInitMixin,
+        SongMultiSelectMixin,
+        PrimaryTabRefreshMixin {
   static const String _prefsSortKey = 'songs_sort_key';
   static const String _prefsSortAsc = 'songs_sort_asc';
   static const double _itemExtent = 64;
@@ -69,6 +69,7 @@ class _SongsPageState extends State<SongsPage>
   late final _isRefreshing = createSignal(false);
 
   bool _hasMoreSongs = true;
+  Future<void>? _initialLoad;
 
   @override
   void initState() {
@@ -79,8 +80,11 @@ class _SongsPageState extends State<SongsPage>
   }
 
   @override
-  Future<void> runDeferredInit() async {
+  Future<void> runDeferredInit() => _initialLoad ??= _initializeSongs();
+
+  Future<void> _initializeSongs() async {
     await _restoreSortPrefs();
+    if (!mounted) return;
     await _loadSongs();
   }
 
@@ -89,6 +93,14 @@ class _SongsPageState extends State<SongsPage>
 
   @override
   Future<void> onPrimaryTabActivated() async {
+    if (_initialLoad == null) {
+      await runDeferredInit();
+      return;
+    }
+    await _initialLoad;
+    if (!mounted) return;
+    // 底栏保留 State，重新进入时同步其他歌曲入口保存的排序。
+    await _restoreSortPrefs(applyInitialOverride: false);
     if (mounted) await _loadSongs();
   }
 
@@ -125,30 +137,41 @@ class _SongsPageState extends State<SongsPage>
     int loaded = 0, skipped = 0;
     for (final song in songs.take(count)) {
       if (song.coverId != null && song.coverId!.isNotEmpty) {
-        final url = api.coverUrl(song.coverId!, size: FeiNiuApiClient.coverRequestSize, updatedAt: song.updatedAt);
+        final url = api.coverUrl(
+          song.coverId!,
+          size: FeiNiuApiClient.coverRequestSize,
+          updatedAt: song.updatedAt,
+        );
         final provider = ResizeImage.resizeIfNeeded(
           memoryCacheSize,
           memoryCacheSize,
           CachedNetworkImageProvider(url, headers: headers),
         );
-        unawaited(precacheImage(
-          provider,
-          context,
-        ).then((_) => loaded++).catchError((e) {
-          debugPrint('[SongsPage] cover precache failed song=${song.title} coverId=${song.coverId}: $e');
-          return 0; // 预缓存失败静默，不阻断后续封面
-        }));
+        unawaited(
+          precacheImage(provider, context).then((_) => loaded++).catchError((
+            e,
+          ) {
+            debugPrint(
+              '[SongsPage] cover precache failed song=${song.title} coverId=${song.coverId}: $e',
+            );
+            return 0; // 预缓存失败静默，不阻断后续封面
+          }),
+        );
       } else {
         skipped++;
       }
     }
     if (loaded > 0 || skipped > 0) {
-      debugPrint('[SongsPage] preloadCovers count=${songs.length} loaded=$loaded skipped=$skipped');
+      debugPrint(
+        '[SongsPage] preloadCovers count=${songs.length} loaded=$loaded skipped=$skipped',
+      );
     }
   }
 
   Future<void> _loadSongs({bool forceRefresh = false}) async {
-    debugPrint('[SongsPage] _loadSongs forceRefresh=$forceRefresh sort=${_apiSortParam()}');
+    debugPrint(
+      '[SongsPage] _loadSongs forceRefresh=$forceRefresh sort=${_apiSortParam()}',
+    );
     _currentPage = 1;
     _hasMoreSongs = true;
 
@@ -161,17 +184,17 @@ class _SongsPageState extends State<SongsPage>
           size: _pageSize,
           sort: sort,
         );
-        debugPrint('[SongsPage] fetch ok total=${pageData.total} items=${pageData.list.length}');
-        final songs = pageData.list
-            .map((t) {
-              try {
-                return _trackService.trackToSongEntity(t.toJson());
-              } catch (e) {
-                debugPrint('[SongsPage] trackToSongEntity error: $e');
-                rethrow;
-              }
-            })
-            .toList();
+        debugPrint(
+          '[SongsPage] fetch ok total=${pageData.total} items=${pageData.list.length}',
+        );
+        final songs = pageData.list.map((t) {
+          try {
+            return _trackService.trackToSongEntity(t.toJson());
+          } catch (e) {
+            debugPrint('[SongsPage] trackToSongEntity error: $e');
+            rethrow;
+          }
+        }).toList();
         _totalSongs = pageData.total;
         _hasMoreSongs = _totalSongs > 0
             ? songs.length < _totalSongs
@@ -239,7 +262,9 @@ class _SongsPageState extends State<SongsPage>
         },
         toJson: (data) {
           final json = jsonEncode(data.map((s) => s.toMap()).toList());
-          debugPrint('[SongsPage] toJson items=${data.length} size=${json.length}B');
+          debugPrint(
+            '[SongsPage] toJson items=${data.length} size=${json.length}B',
+          );
           return json;
         },
         fetchCallback: onData,
@@ -247,7 +272,9 @@ class _SongsPageState extends State<SongsPage>
 
       if (cached != null) {
         // 缓存命中 → 全屏转圈消失，右上角转圈保持直到后台刷新结束
-        debugPrint('[SongsPage] cache hit, songs=${cached.length}, background refresh started');
+        debugPrint(
+          '[SongsPage] cache hit, songs=${cached.length}, background refresh started',
+        );
         if (mounted) {
           _songs.value = cached;
           _isLoading.value = false;
@@ -342,7 +369,7 @@ class _SongsPageState extends State<SongsPage>
     await _loadMoreToTarget(target);
   }
 
-  Future<void> _restoreSortPrefs() async {
+  Future<void> _restoreSortPrefs({bool applyInitialOverride = true}) async {
     final prefs = await SharedPreferences.getInstance();
     final sortKey = prefs.getString(_prefsSortKey);
     final sortAsc = prefs.getBool(_prefsSortAsc);
@@ -355,10 +382,10 @@ class _SongsPageState extends State<SongsPage>
     }
     // 一次性排序覆盖：仅本次进入生效，不改写持久化偏好。
     // 首页「最新歌曲」入口要求默认按创建时间降序。
-    if (widget.initialSortKey != null) {
+    if (applyInitialOverride && widget.initialSortKey != null) {
       _sortKey.value = widget.initialSortKey!;
     }
-    if (widget.initialAscending != null) {
+    if (applyInitialOverride && widget.initialAscending != null) {
       _ascending.value = widget.initialAscending!;
     }
   }
@@ -385,21 +412,19 @@ class _SongsPageState extends State<SongsPage>
   }
 
   void _openSearch() {
-    Navigator.pushNamed(context, AppRoutes.search, arguments: SearchCategory.song);
+    Navigator.pushNamed(
+      context,
+      AppRoutes.search,
+      arguments: SearchCategory.song,
+    );
   }
 
   /// 打开文件夹视图（服务端增强）。未开启时引导到设置页。
   void _openFolders() {
     if (LyricCompanionSettings.enabled.value) {
-      Navigator.of(context).push(
-        buildAppPageRoute((_) => const FoldersPage()),
-      );
+      Navigator.of(context).push(buildAppPageRoute((_) => const FoldersPage()));
     } else {
-      AppToast.show(
-        context,
-        '请先在设置 → 元数据管理开启「服务端增强」',
-        type: ToastType.error,
-      );
+      AppToast.show(context, '请先在设置 → 元数据管理开启「服务端增强」', type: ToastType.error);
     }
   }
 
@@ -432,7 +457,11 @@ class _SongsPageState extends State<SongsPage>
         return SortSheet(
           title: '歌曲排序',
           options: const [
-            SortOption(key: 'title', label: '歌曲名', icon: Icons.music_note_outlined),
+            SortOption(
+              key: 'title',
+              label: '歌曲名',
+              icon: Icons.music_note_outlined,
+            ),
             SortOption(key: 'duration', label: '创建时间', icon: Icons.access_time),
           ],
           currentKey: _sortKey.value,
@@ -467,14 +496,15 @@ class _SongsPageState extends State<SongsPage>
             leading: useBottomNavigation || AppLayoutSettings.tvMode.value
                 ? null
                 : (isMultiSelecting
-                    ? IconButton(
-                        icon: const Icon(Icons.close_rounded),
-                        onPressed: exitMultiSelect,
-                      )
-                    : IconButton(
-                        icon: const Icon(Icons.menu_rounded),
-                        onPressed: () => _scaffoldKey.currentState?.openDrawer(),
-                      )),
+                      ? IconButton(
+                          icon: const Icon(Icons.close_rounded),
+                          onPressed: exitMultiSelect,
+                        )
+                      : IconButton(
+                          icon: const Icon(Icons.menu_rounded),
+                          onPressed: () =>
+                              _scaffoldKey.currentState?.openDrawer(),
+                        )),
             actions: isMultiSelecting
                 ? [
                     SelectAllButton(
@@ -606,7 +636,8 @@ class _SongsPageState extends State<SongsPage>
                       child: ListView.builder(
                         controller: _listController,
                         padding: const EdgeInsets.fromLTRB(16, 0, 16, 120),
-                        itemCount: songs.length + (_isLoadingMore.value ? 1 : 0),
+                        itemCount:
+                            songs.length + (_isLoadingMore.value ? 1 : 0),
                         itemExtent: _itemExtent,
                         addAutomaticKeepAlives: true,
                         scrollCacheExtent: ScrollCacheExtent.pixels(300),
@@ -619,7 +650,8 @@ class _SongsPageState extends State<SongsPage>
                                   width: 20,
                                   height: 20,
                                   child: CircularProgressIndicator(
-                                      strokeWidth: 2),
+                                    strokeWidth: 2,
+                                  ),
                                 ),
                               ),
                             );
@@ -671,10 +703,8 @@ class _SongsPageState extends State<SongsPage>
           if (artistGuid != null) {
             Navigator.of(context).push(
               MaterialPageRoute(
-                builder: (_) => ArtistDetailPage(
-                  artistName: name,
-                  artistGuid: artistGuid,
-                ),
+                builder: (_) =>
+                    ArtistDetailPage(artistName: name, artistGuid: artistGuid),
               ),
             );
           }
@@ -684,10 +714,8 @@ class _SongsPageState extends State<SongsPage>
           if (guid != null) {
             Navigator.of(context).push(
               MaterialPageRoute(
-                builder: (_) => AlbumDetailPage(
-                  albumName: name,
-                  albumGuid: guid,
-                ),
+                builder: (_) =>
+                    AlbumDetailPage(albumName: name, albumGuid: guid),
               ),
             );
           }
@@ -719,11 +747,7 @@ class _SongListTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final leading = ArtworkWidget(
-      song: song,
-      size: 48,
-      borderRadius: 8,
-    );
+    final leading = ArtworkWidget(song: song, size: 48, borderRadius: 8);
     return InkWell(
       onTap: onTap,
       onLongPress: onLongPress,

--- a/test/songs_sort_navigation_test.dart
+++ b/test/songs_sort_navigation_test.dart
@@ -1,0 +1,97 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:feiniu_music/app/services/db/db_helper.dart';
+
+import 'package:feiniu_music/app/services/feiniu/api_client.dart';
+import 'package:feiniu_music/app/state/settings_layout_state.dart';
+import 'package:feiniu_music/app/utils/primary_shell_scope.dart';
+import 'package:feiniu_music/components/layout/modern_navigation_bar.dart';
+import 'package:feiniu_music/pages/songs/songs_page.dart';
+
+Future<void> pumpPage(WidgetTester tester) async {
+  // 页面有持续动画，按固定帧数推进而不等待动画停止。
+  for (var frame = 0; frame < 20; frame++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+void main() {
+  testWidgets('cached songs tab reloads the latest saved sort on reentry', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({
+      'songs_sort_key': 'duration',
+      'songs_sort_asc': false,
+    });
+    AppLayoutSettings.resetForTest();
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfiNoIsolate;
+    DbHelper.instance.resetForTest(overridePath: inMemoryDatabasePath);
+    await tester.runAsync(() async {
+      await DbHelper.instance.database;
+    });
+    addTearDown(() => DbHelper.instance.resetForTest());
+    final sorts = <String>[];
+    final dio = Dio();
+    dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) {
+          if (options.path.endsWith('/track/list')) {
+            sorts.add(options.queryParameters['sort'] as String);
+          }
+          handler.resolve(
+            Response(
+              requestOptions: options,
+              data: {
+                'code': 0,
+                'data': {'list': [], 'total': 0},
+              },
+            ),
+          );
+        },
+      ),
+    );
+    FeiNiuApiClient.instance.setDioForTest(dio);
+    final index = ValueNotifier(2);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ValueListenableBuilder<int>(
+          valueListenable: index,
+          builder: (context, value, child) => PrimaryShellMarker(
+            child: PrimaryNavigationScope(
+              currentIndex: value,
+              onSelected: (value) => index.value = value,
+              child: IndexedStack(
+                index: value == 2 ? 0 : 1,
+                children: const [SongsPage(), SizedBox()],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await pumpPage(tester);
+    expect(sorts, ['createdAt,desc']);
+    final originalState = tester.state(find.byType(SongsPage));
+    index.value = 0;
+    await pumpPage(tester);
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('songs_sort_key', 'title');
+    await prefs.setBool('songs_sort_asc', true);
+    index.value = 2;
+    await pumpPage(tester);
+    expect(tester.state(find.byType(SongsPage)), same(originalState));
+    expect(sorts.last, 'title,asc');
+    index.value = 0;
+    await pumpPage(tester);
+    index.value = 2;
+    await pumpPage(tester);
+    expect(sorts.last, 'title,asc');
+    await tester.pumpWidget(const SizedBox());
+    await pumpPage(tester);
+    index.dispose();
+  });
+}


### PR DESCRIPTION
修复安卓端歌曲排序在重新进入列表时恢复默认创建时间降序的问题。同步保存的排序偏好，并移除首页入口的强制排序覆盖。\n\nCloses #85\n\n验证：排序回归测试通过，全量 Flutter 测试通过。